### PR TITLE
Add "unzip" for dependent docker files

### DIFF
--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:wheezy
 #  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
 #       really hairy.
 
-RUN apt-get update && apt-get install -y curl openjdk-6-jdk=6b32* wget
+RUN apt-get update && apt-get install -y curl openjdk-6-jdk=6b32* unzip wget
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:jessie
 #  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
 #       really hairy.
 
-RUN apt-get update && apt-get install -y curl openjdk-7-jdk=7u65* wget
+RUN apt-get update && apt-get install -y curl openjdk-7-jdk=7u65* unzip wget
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:experimental
 #  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
 #       really hairy.
 
-RUN apt-get update && apt-get install -y curl openjdk-8-jdk=8u20* wget
+RUN apt-get update && apt-get install -y curl openjdk-8-jdk=8u20* unzip wget
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!


### PR DESCRIPTION
Useful for unpacking code or manually installing WAR files in dependent docker images.

Also had to update the version number of openjdk-7 to avoid errors from the package manager.
