### PR TITLE
Update tagging logic to make betas more obvious

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -25,11 +25,17 @@ for version in "${versions[@]}"; do
 	javaType="${javaVersion##*-}" # "jdk"
 	javaVersion="${javaVersion%-*}" # "6"
 	
-	fullVersion="$(grep -m1 'ENV JAVA_VERSION ' "$version/Dockerfile" | cut -d' ' -f3)"
+	fullVersion="$(grep -m1 'ENV JAVA_VERSION ' "$version/Dockerfile" | cut -d' ' -f3 | tr '~' '-')"
 	
-	bases=( $flavor-$fullVersion $flavor-$javaVersion )
+	bases=( $flavor-$fullVersion )
+	if [ "${fullVersion%-*}" != "$fullVersion" ]; then
+		bases+=( $flavor-${fullVersion%-*} ) # like "8u40-b09
+	fi
+	bases+=( $flavor-$javaVersion )
 	if [ "$flavor" = "$defaultFlavor" ]; then
-		bases+=( $fullVersion $javaVersion )
+		for base in "${bases[@]}"; do
+			bases+=( "${base#$flavor-}" )
+		done
 	fi
 	
 	versionAliases=()

--- a/openjdk-8-jdk/Dockerfile
+++ b/openjdk-8-jdk/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:sid
 #  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
 #       really hairy.
 
-ENV JAVA_VERSION 8u40
+ENV JAVA_VERSION 8u40~b09
 
 RUN apt-get update && apt-get install -y curl openjdk-8-jdk="$JAVA_VERSION"* unzip wget
 

--- a/openjdk-8-jre/Dockerfile
+++ b/openjdk-8-jre/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:sid
 #  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
 #       really hairy.
 
-ENV JAVA_VERSION 8u40
+ENV JAVA_VERSION 8u40~b09
 
 RUN apt-get update && apt-get install -y curl openjdk-8-jre-headless="$JAVA_VERSION"* unzip wget
 

--- a/update.sh
+++ b/update.sh
@@ -22,7 +22,7 @@ for version in "${versions[@]}"; do
 	case "$flavor" in
 		openjdk)
 			fullVersion="$(set -x; docker run --rm debian:"$dist" bash -c "apt-get update &> /dev/null && apt-cache show $flavor-$javaVersion-$javaType | grep '^Version: ' | head -1 | cut -d' ' -f2")"
-			fullVersion="${fullVersion%%[-~]*}"
+			fullVersion="${fullVersion%%-*}"
 			;;
 	esac
 	


### PR DESCRIPTION
This makes it much more clear when, for example, our `8` is a beta build, by tagging it explicitly as `8u40-b09` as well:

``` console
$ ./generate-stackbrew-library.sh
...

openjdk-8u40-b09-jdk: git://github.com/docker-library/java@9b3b7ed1bdd754fa61b5dd86c0bcd3e3400c6a33 openjdk-8-jdk
openjdk-8u40-b09: git://github.com/docker-library/java@9b3b7ed1bdd754fa61b5dd86c0bcd3e3400c6a33 openjdk-8-jdk
openjdk-8u40-jdk: git://github.com/docker-library/java@9b3b7ed1bdd754fa61b5dd86c0bcd3e3400c6a33 openjdk-8-jdk
openjdk-8u40: git://github.com/docker-library/java@9b3b7ed1bdd754fa61b5dd86c0bcd3e3400c6a33 openjdk-8-jdk
openjdk-8-jdk: git://github.com/docker-library/java@9b3b7ed1bdd754fa61b5dd86c0bcd3e3400c6a33 openjdk-8-jdk
openjdk-8: git://github.com/docker-library/java@9b3b7ed1bdd754fa61b5dd86c0bcd3e3400c6a33 openjdk-8-jdk
8u40-b09-jdk: git://github.com/docker-library/java@9b3b7ed1bdd754fa61b5dd86c0bcd3e3400c6a33 openjdk-8-jdk
8u40-b09: git://github.com/docker-library/java@9b3b7ed1bdd754fa61b5dd86c0bcd3e3400c6a33 openjdk-8-jdk
8u40-jdk: git://github.com/docker-library/java@9b3b7ed1bdd754fa61b5dd86c0bcd3e3400c6a33 openjdk-8-jdk
8u40: git://github.com/docker-library/java@9b3b7ed1bdd754fa61b5dd86c0bcd3e3400c6a33 openjdk-8-jdk
8-jdk: git://github.com/docker-library/java@9b3b7ed1bdd754fa61b5dd86c0bcd3e3400c6a33 openjdk-8-jdk
8: git://github.com/docker-library/java@9b3b7ed1bdd754fa61b5dd86c0bcd3e3400c6a33 openjdk-8-jdk

openjdk-8u40-b09-jre: git://github.com/docker-library/java@bcf0fea5a62cb2a75015e2dc2ce05bbc89afcd7d openjdk-8-jre
openjdk-8u40-jre: git://github.com/docker-library/java@bcf0fea5a62cb2a75015e2dc2ce05bbc89afcd7d openjdk-8-jre
openjdk-8-jre: git://github.com/docker-library/java@bcf0fea5a62cb2a75015e2dc2ce05bbc89afcd7d openjdk-8-jre
8u40-b09-jre: git://github.com/docker-library/java@bcf0fea5a62cb2a75015e2dc2ce05bbc89afcd7d openjdk-8-jre
8u40-jre: git://github.com/docker-library/java@bcf0fea5a62cb2a75015e2dc2ce05bbc89afcd7d openjdk-8-jre
8-jre: git://github.com/docker-library/java@bcf0fea5a62cb2a75015e2dc2ce05bbc89afcd7d openjdk-8-jre
```
