### PR TITLE
Fix for a single multi-line ENV statement

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -25,7 +25,7 @@ for version in "${versions[@]}"; do
 	javaType="${javaVersion##*-}" # "jdk"
 	javaVersion="${javaVersion%-*}" # "6"
 	
-	fullVersion="$(grep -m1 'ENV JAVA_VERSION ' "$version/Dockerfile" | cut -d' ' -f3 | tr '~' '-')"
+	fullVersion="$(grep -m1 -E -o '\bJAVA_VERSION=[^ \t\n]*' "$version/Dockerfile" | cut -d'=' -f2 | tr '~' '-')"
 	
 	bases=( $flavor-$fullVersion )
 	if [ "${fullVersion%-*}" != "$fullVersion" ]; then

--- a/openjdk-6-jdk/Dockerfile
+++ b/openjdk-6-jdk/Dockerfile
@@ -8,10 +8,9 @@ FROM buildpack-deps:wheezy-scm
 RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 
 # Default to UTF-8 file.encoding
-ENV LANG C.UTF-8
-
-ENV JAVA_VERSION 6b35
-ENV JAVA_DEBIAN_VERSION 6b35-1.13.7-1~deb7u1
+ENV LANG=C.UTF-8 \
+	JAVA_VERSION=6b35 \
+	JAVA_DEBIAN_VERSION=6b35-1.13.7-1~deb7u1
 
 RUN apt-get update && apt-get install -y openjdk-6-jdk="$JAVA_DEBIAN_VERSION" && rm -rf /var/lib/apt/lists/*
 

--- a/openjdk-6-jre/Dockerfile
+++ b/openjdk-6-jre/Dockerfile
@@ -8,10 +8,9 @@ FROM buildpack-deps:wheezy-curl
 RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 
 # Default to UTF-8 file.encoding
-ENV LANG C.UTF-8
-
-ENV JAVA_VERSION 6b35
-ENV JAVA_DEBIAN_VERSION 6b35-1.13.7-1~deb7u1
+ENV LANG=C.UTF-8 \
+	JAVA_VERSION=6b35 \
+	JAVA_DEBIAN_VERSION=6b35-1.13.7-1~deb7u1
 
 RUN apt-get update && apt-get install -y openjdk-6-jre-headless="$JAVA_DEBIAN_VERSION" && rm -rf /var/lib/apt/lists/*
 

--- a/openjdk-7-jdk/Dockerfile
+++ b/openjdk-7-jdk/Dockerfile
@@ -8,10 +8,9 @@ FROM buildpack-deps:jessie-scm
 RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 
 # Default to UTF-8 file.encoding
-ENV LANG C.UTF-8
-
-ENV JAVA_VERSION 7u79
-ENV JAVA_DEBIAN_VERSION 7u79-2.5.5-1~deb8u1
+ENV LANG=C.UTF-8 \
+	JAVA_VERSION=7u79 \
+	JAVA_DEBIAN_VERSION=7u79-2.5.5-1~deb8u1
 
 RUN apt-get update && apt-get install -y openjdk-7-jdk="$JAVA_DEBIAN_VERSION" && rm -rf /var/lib/apt/lists/*
 

--- a/openjdk-7-jre/Dockerfile
+++ b/openjdk-7-jre/Dockerfile
@@ -8,10 +8,9 @@ FROM buildpack-deps:jessie-curl
 RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 
 # Default to UTF-8 file.encoding
-ENV LANG C.UTF-8
-
-ENV JAVA_VERSION 7u79
-ENV JAVA_DEBIAN_VERSION 7u79-2.5.5-1~deb8u1
+ENV LANG=C.UTF-8 \
+	JAVA_VERSION=7u79 \
+	JAVA_DEBIAN_VERSION=7u79-2.5.5-1~deb8u1
 
 RUN apt-get update && apt-get install -y openjdk-7-jre-headless="$JAVA_DEBIAN_VERSION" && rm -rf /var/lib/apt/lists/*
 

--- a/openjdk-8-jdk/Dockerfile
+++ b/openjdk-8-jdk/Dockerfile
@@ -8,10 +8,9 @@ FROM buildpack-deps:sid-scm
 RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 
 # Default to UTF-8 file.encoding
-ENV LANG C.UTF-8
-
-ENV JAVA_VERSION 8u45
-ENV JAVA_DEBIAN_VERSION 8u45-b14-2
+ENV LANG=C.UTF-8 \
+	JAVA_VERSION=8u45 \
+	JAVA_DEBIAN_VERSION=8u45-b14-2
 
 # see https://bugs.debian.org/775775
 # and https://github.com/docker-library/java/issues/19#issuecomment-70546872

--- a/openjdk-8-jre/Dockerfile
+++ b/openjdk-8-jre/Dockerfile
@@ -8,10 +8,9 @@ FROM buildpack-deps:sid-curl
 RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 
 # Default to UTF-8 file.encoding
-ENV LANG C.UTF-8
-
-ENV JAVA_VERSION 8u45
-ENV JAVA_DEBIAN_VERSION 8u45-b14-2
+ENV LANG=C.UTF-8 \
+	JAVA_VERSION=8u45 \
+	JAVA_DEBIAN_VERSION=8u45-b14-2
 
 # see https://bugs.debian.org/775775
 # and https://github.com/docker-library/java/issues/19#issuecomment-70546872

--- a/update.sh
+++ b/update.sh
@@ -30,8 +30,8 @@ for version in "${versions[@]}"; do
 		(
 			set -x
 			sed -ri '
-				s/(ENV JAVA_VERSION) .*/\1 '"$fullVersion"'/g;
-				s/(ENV JAVA_DEBIAN_VERSION) .*/\1 '"$debianVersion"'/g;
+				s/\b(JAVA_VERSION)=[^ \t\n]*/\1='"$fullVersion"'/g
+				s/\b(JAVA_DEBIAN_VERSION)=[^ \t\n]*/\1='"$debianVersion"'/g;
 			' "$version/Dockerfile"
 		)
 	fi


### PR DESCRIPTION
My suggested changes for combining the separate `ENV` statements into one multi-line `ENV` statement, as proposed in https://github.com/docker-library/java/issues/35. Also updated `update.sh` and `generate-stackbrew-library.sh` to work with the new format (which breaks compatibility with the current format!).