### PR TITLE
Add script to make it easier to set Xmx values

### DIFF
--- a/docker-jvm-opts.sh
+++ b/docker-jvm-opts.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Return reasonable JVM options to run inside a Docker container where memory and
+# CPU can be limited with cgroups.
+# https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/parallel.html
+#
+# The script can be used in a custom CMD or ENTRYPOINT
+#
+# export _JAVA_OPTIONS=$(/usr/local/bin/docker-jvm-opts.sh)
+
+# Options:
+#   JVM_HEAP_RATIO=0.5 Ratio of heap size to available memory
+
+# If Xmx is not set the JVM will use by default 1/4th (in most cases) of the host memory
+# This can cause the Kernel to kill the container if the JVM memory grows over the cgroups limit
+# because the JVM is not aware of that limit and doesn't invoke the GC
+# Setting it by default to 0.5 times the memory limited by cgroups, customizable with JVM_HEAP_RATIO
+CGROUPS_MEM=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+MEMINFO_MEM=$(($(awk '/MemTotal/ {print $2}' /proc/meminfo)*1024))
+MEM=$(($MEMINFO_MEM>$CGROUPS_MEM?$CGROUPS_MEM:$MEMINFO_MEM))
+JVM_HEAP_RATIO=${JVM_HEAP_RATIO:-0.5}
+XMX=$(awk '{printf("%d",$1*$2/1024^2)}' <<<" ${MEM} ${JVM_HEAP_RATIO} ")
+
+# TODO handle cpu limits into -XX:ParallelGCThreads
+
+echo "-Xmx${XMX}m"

--- a/update.sh
+++ b/update.sh
@@ -81,6 +81,8 @@ for version in "${versions[@]}"; do
 	fi
 	fullVersion="${debianVersion%%-*}"
 
+  cp docker-jvm-opts.sh "$version"
+
 	cat > "$version/Dockerfile" <<-EOD
 		#
 		# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
@@ -163,6 +165,8 @@ EOD
 	fi
 
 	cat >> "$version/Dockerfile" <<-EOD
+
+COPY docker-jvm-opts.sh /usr/local/bin/docker-jvm-opts.sh
 
 		# If you're reading this and have any feedback on how this image could be
 		#   improved, please open an issue or a pull request so we can discuss it!


### PR DESCRIPTION
From #59 

A script to set better default Xmx values according to the docker memory limits from /sys/fs/cgroup/memory/memory.limit_in_bytes

If Xmx is not set the JVM will use by default 1/4th (in most cases) of the host memory
This can cause the Kernel to kill the container if the JVM memory grows over the cgroups limit
because the JVM is not aware of that limit and doesn't invoke the GC
Setting it by default to 0.5 times the memory limited by cgroups, customizable with JVM_HEAP_RATIO

Example

```
docker run -m 256m -e JVM_HEAP_RATIO=0.9 -ti --rm java /usr/local/bin/docker-jvm-opts.sh
-Xmx128m
docker run -m 256m -e JVM_HEAP_RATIO=0.9 -ti --rm java /usr/local/bin/docker-jvm-opts.sh
-Xmx230m
```
