### PR TITLE
Proposal: Add Windows version of OpenJDK

### DIFF
--- a/8-jdk/windows/build.sh
+++ b/8-jdk/windows/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+docker build -t openjdk:8-windowsservercore windowsservercore
+docker build -t openjdk:8-nanoserver nanoserver
+docker run openjdk:8-windowsservercore java -version
+docker run openjdk:8-nanoserver java -version

--- a/8-jdk/windows/build.sh
+++ b/8-jdk/windows/build.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-docker build -t openjdk:8-windowsservercore windowsservercore
-docker build -t openjdk:8-nanoserver nanoserver
-docker run openjdk:8-windowsservercore java -version
-docker run openjdk:8-nanoserver java -version

--- a/8-jdk/windows/nanoserver/Dockerfile
+++ b/8-jdk/windows/nanoserver/Dockerfile
@@ -1,0 +1,16 @@
+FROM microsoft/nanoserver
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV JAVA_VERSION 1.8.0.111-3
+ENV JAVA_ZIP_VERSION 1.8.0-openjdk-1.8.0.111-3.b15
+ENV JAVA_SHA256 e080371bf57536668416157660e05d95fe04db15da36234d32bda8e301bb0454
+
+ENV JAVA_HOME C:\\java-${JAVA_ZIP_VERSION}.ojdkbuild.windows.x86_64
+
+RUN Invoke-WebRequest $('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/java-{1}.ojdkbuild.windows.x86_64.zip' -f $env:JAVA_VERSION, $env:JAVA_ZIP_VERSION) -OutFile 'openjdk.zip' -UseBasicParsing ; \
+    if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) {exit 1} ; \
+    Expand-Archive openjdk.zip -DestinationPath C:\ ; \
+    $env:PATH = '{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH ; \
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $env:PATH ; \
+    Remove-Item -Path openjdk.zip

--- a/8-jdk/windows/nanoserver/Dockerfile
+++ b/8-jdk/windows/nanoserver/Dockerfile
@@ -1,16 +1,43 @@
 FROM microsoft/nanoserver
 
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION 1.8.0.111-3
-ENV JAVA_ZIP_VERSION 1.8.0-openjdk-1.8.0.111-3.b15
-ENV JAVA_SHA256 e080371bf57536668416157660e05d95fe04db15da36234d32bda8e301bb0454
+ENV JAVA_HOME C:\\ojdkbuild
+RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+# Nano Server does not have "[Environment]::SetEnvironmentVariable()"
+	setx /M PATH $newPath;
 
-ENV JAVA_HOME C:\\java-${JAVA_ZIP_VERSION}.ojdkbuild.windows.x86_64
+# https://github.com/ojdkbuild/ojdkbuild/releases
+ENV JAVA_VERSION 8u111
+ENV JAVA_OJDKBUILD_VERSION 1.8.0.111-3
+ENV JAVA_OJDKBUILD_ZIP java-1.8.0-openjdk-1.8.0.111-3.b15.ojdkbuild.windows.x86_64.zip
+ENV JAVA_OJDKBUILD_SHA256 e080371bf57536668416157660e05d95fe04db15da36234d32bda8e301bb0454
 
-RUN Invoke-WebRequest $('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/java-{1}.ojdkbuild.windows.x86_64.zip' -f $env:JAVA_VERSION, $env:JAVA_ZIP_VERSION) -OutFile 'openjdk.zip' -UseBasicParsing ; \
-    if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) {exit 1} ; \
-    Expand-Archive openjdk.zip -DestinationPath C:\ ; \
-    $env:PATH = '{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH ; \
-    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $env:PATH ; \
-    Remove-Item -Path openjdk.zip
+RUN $url = ('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/{1}' -f $env:JAVA_OJDKBUILD_VERSION, $env:JAVA_OJDKBUILD_ZIP); \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	Invoke-WebRequest -Uri $url -OutFile 'ojdkbuild.zip'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_OJDKBUILD_SHA256); \
+	if ((Get-FileHash ojdkbuild.zip -Algorithm sha256).Hash -ne $env:JAVA_OJDKBUILD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive ojdkbuild.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Renaming ...'; \
+	Move-Item \
+		-Path ('C:\{0}' -f ($env:JAVA_OJDKBUILD_ZIP -Replace '.zip$', '')) \
+		-Destination $env:JAVA_HOME \
+	; \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  java -version'; java -version; \
+	Write-Host '  javac -version'; javac -version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item ojdkbuild.zip -Force; \
+	\
+	Write-Host 'Complete.';

--- a/8-jdk/windows/windowsservercore/Dockerfile
+++ b/8-jdk/windows/windowsservercore/Dockerfile
@@ -1,16 +1,43 @@
 FROM microsoft/windowsservercore
 
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION 1.8.0.111-3
-ENV JAVA_ZIP_VERSION 1.8.0-openjdk-1.8.0.111-3.b15
-ENV JAVA_SHA256 e080371bf57536668416157660e05d95fe04db15da36234d32bda8e301bb0454
+ENV JAVA_HOME C:\\ojdkbuild
+RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+# Nano Server does not have "[Environment]::SetEnvironmentVariable()"
+	setx /M PATH $newPath;
 
-ENV JAVA_HOME C:\\java-${JAVA_ZIP_VERSION}.ojdkbuild.windows.x86_64
+# https://github.com/ojdkbuild/ojdkbuild/releases
+ENV JAVA_VERSION 8u111
+ENV JAVA_OJDKBUILD_VERSION 1.8.0.111-3
+ENV JAVA_OJDKBUILD_ZIP java-1.8.0-openjdk-1.8.0.111-3.b15.ojdkbuild.windows.x86_64.zip
+ENV JAVA_OJDKBUILD_SHA256 e080371bf57536668416157660e05d95fe04db15da36234d32bda8e301bb0454
 
-RUN Invoke-WebRequest $('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/java-{1}.ojdkbuild.windows.x86_64.zip' -f $env:JAVA_VERSION, $env:JAVA_ZIP_VERSION) -OutFile 'openjdk.zip' -UseBasicParsing ; \
-    if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) {exit 1} ; \
-    Expand-Archive openjdk.zip -DestinationPath C:\ ; \
-    $env:PATH = '{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH ; \
-    [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine) ; \
-    Remove-Item -Path openjdk.zip
+RUN $url = ('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/{1}' -f $env:JAVA_OJDKBUILD_VERSION, $env:JAVA_OJDKBUILD_ZIP); \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	Invoke-WebRequest -Uri $url -OutFile 'ojdkbuild.zip'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_OJDKBUILD_SHA256); \
+	if ((Get-FileHash ojdkbuild.zip -Algorithm sha256).Hash -ne $env:JAVA_OJDKBUILD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive ojdkbuild.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Renaming ...'; \
+	Move-Item \
+		-Path ('C:\{0}' -f ($env:JAVA_OJDKBUILD_ZIP -Replace '.zip$', '')) \
+		-Destination $env:JAVA_HOME \
+	; \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  java -version'; java -version; \
+	Write-Host '  javac -version'; javac -version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item ojdkbuild.zip -Force; \
+	\
+	Write-Host 'Complete.';

--- a/8-jdk/windows/windowsservercore/Dockerfile
+++ b/8-jdk/windows/windowsservercore/Dockerfile
@@ -1,0 +1,16 @@
+FROM microsoft/windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV JAVA_VERSION 1.8.0.111-3
+ENV JAVA_ZIP_VERSION 1.8.0-openjdk-1.8.0.111-3.b15
+ENV JAVA_SHA256 e080371bf57536668416157660e05d95fe04db15da36234d32bda8e301bb0454
+
+ENV JAVA_HOME C:\\java-${JAVA_ZIP_VERSION}.ojdkbuild.windows.x86_64
+
+RUN Invoke-WebRequest $('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/java-{1}.ojdkbuild.windows.x86_64.zip' -f $env:JAVA_VERSION, $env:JAVA_ZIP_VERSION) -OutFile 'openjdk.zip' -UseBasicParsing ; \
+    if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) {exit 1} ; \
+    Expand-Archive openjdk.zip -DestinationPath C:\ ; \
+    $env:PATH = '{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH ; \
+    [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine) ; \
+    Remove-Item -Path openjdk.zip

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -109,18 +109,25 @@ for version in "${versions[@]}"; do
 		Directory: $version
 	EOE
 
-	for variant in alpine; do
-		[ -f "$version/$variant/Dockerfile" ] || continue
+	for v in \
+		alpine \
+		windows/windowsservercore windows/nanoserver \
+	; do
+		dir="$version/$v"
+		variant="$(basename "$v")"
 
-		commit="$(dirCommit "$version/$variant")"
+		[ -f "$dir/Dockerfile" ] || continue
 
-		fullVersion="$(git show "$commit":"$version/$variant/Dockerfile" | awk '$1 == "ENV" && $2 == "JAVA_VERSION" { gsub(/~/, "-", $3); print $3; exit }')"
+		commit="$(dirCommit "$dir")"
+
+		fullVersion="$(git show "$commit":"$dir/Dockerfile" | awk '$1 == "ENV" && $2 == "JAVA_VERSION" { gsub(/~/, "-", $3); print $3; exit }')"
 
 		echo
 		cat <<-EOE
 			Tags: $(join ', ' $(aliases "$javaVersion" "$javaType" "$fullVersion" "$variant"))
 			GitCommit: $commit
-			Directory: $version/$variant
+			Directory: $dir
 		EOE
+		[ "$variant" = "$v" ] || echo "Constraints: $variant"
 	done
 done


### PR DESCRIPTION
Here are some Dockerfiles to build Windows docker images with OpenJDK from RedHat. These might be a starting point to get an official `openjdk:8-windowsservercore` and `openjdk:8-nanoserver` image on the Docker Hub.

I first started to put Oracle Java into container images which ended in the PR https://github.com/oracle/docker-images/pull/209, but everybody has to build its own version.

The idea for this variant started after I saw this image https://hub.docker.com/r/michaeltlombardi/nanoserveropenjdk/ and wondered that OpenJDK is available for Windows, too.

Yes, it is: http://developers.redhat.com/products/openjdk/overview/

So I started a Dockerfile to download the MSI package, but there is the first hard problem that the download is only available after logging in. So you have to download the MSI package on your host machine.

For the Nano Server variant I also could not use the MSI package, so the `build.sh` script copies the installed folder to the host and a nanoserver image is then created by COPYing this directory back into the image.

After this worked, I thought this would also help the windowsservercore image to reduce the size of the image as I couldn't remove the MSI package after the first COPY. So the final windowsservercore image is created in the same way as the nanoserver image.

One problem might be if it is allowed to publish such image as RedHat has put that "open" OpenJDK behind a login. The agreement says something about using this only for development and not for production...
