### PR TITLE
Revert Alpine 3.5 upgrade in 7 and 8 (leaving 9 on Alpine 3.5)

### DIFF
--- a/7-jdk/alpine/Dockerfile
+++ b/7-jdk/alpine/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.5
+FROM alpine:3.4
 
 # A few problems with compiling Java from source:
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.

--- a/7-jre/alpine/Dockerfile
+++ b/7-jre/alpine/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.5
+FROM alpine:3.4
 
 # A few problems with compiling Java from source:
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.

--- a/8-jdk/alpine/Dockerfile
+++ b/8-jdk/alpine/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.5
+FROM alpine:3.4
 
 # A few problems with compiling Java from source:
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.
@@ -27,7 +27,7 @@ ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
 ENV PATH $PATH:/usr/lib/jvm/java-1.8-openjdk/jre/bin:/usr/lib/jvm/java-1.8-openjdk/bin
 
 ENV JAVA_VERSION 8u111
-ENV JAVA_ALPINE_VERSION 8.111.14-r1
+ENV JAVA_ALPINE_VERSION 8.111.14-r0
 
 RUN set -x \
 	&& apk add --no-cache \

--- a/8-jre/alpine/Dockerfile
+++ b/8-jre/alpine/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.5
+FROM alpine:3.4
 
 # A few problems with compiling Java from source:
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.
@@ -27,7 +27,7 @@ ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk/jre
 ENV PATH $PATH:/usr/lib/jvm/java-1.8-openjdk/jre/bin:/usr/lib/jvm/java-1.8-openjdk/bin
 
 ENV JAVA_VERSION 8u111
-ENV JAVA_ALPINE_VERSION 8.111.14-r1
+ENV JAVA_ALPINE_VERSION 8.111.14-r0
 
 RUN set -x \
 	&& apk add --no-cache \


### PR DESCRIPTION
See https://github.com/docker-library/golang/pull/131#issuecomment-270677556 for further discussion.