### PR TITLE
Update to 8u121, debian 8u121-b13-1~bpo8+1

### DIFF
--- a/8-jdk/Dockerfile
+++ b/8-jdk/Dockerfile
@@ -34,12 +34,12 @@ RUN { \
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
-ENV JAVA_VERSION 8u111
-ENV JAVA_DEBIAN_VERSION 8u111-b14-2~bpo8+1
+ENV JAVA_VERSION 8u121
+ENV JAVA_DEBIAN_VERSION 8u121-b13-1~bpo8+1
 
 # see https://bugs.debian.org/775775
 # and https://github.com/docker-library/java/issues/19#issuecomment-70546872
-ENV CA_CERTIFICATES_JAVA_VERSION 20140324
+ENV CA_CERTIFICATES_JAVA_VERSION 20161107~bpo8+1
 
 RUN set -x \
 	&& apt-get update \

--- a/8-jre/Dockerfile
+++ b/8-jre/Dockerfile
@@ -34,12 +34,12 @@ RUN { \
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/jre
 
-ENV JAVA_VERSION 8u111
-ENV JAVA_DEBIAN_VERSION 8u111-b14-2~bpo8+1
+ENV JAVA_VERSION 8u121
+ENV JAVA_DEBIAN_VERSION 8u121-b13-1~bpo8+1
 
 # see https://bugs.debian.org/775775
 # and https://github.com/docker-library/java/issues/19#issuecomment-70546872
-ENV CA_CERTIFICATES_JAVA_VERSION 20140324
+ENV CA_CERTIFICATES_JAVA_VERSION 20161107~bpo8+1
 
 RUN set -x \
 	&& apt-get update \


### PR DESCRIPTION
openjdk `8u111-b14-2~bpo8+1` is no longer available in Debian Jessie, without this commit the `8-jre` and `8-jdk` flavours do not build.

---

I created a fork for the time being with automated builds, for those who need. See [comment](https://github.com/docker-library/openjdk/pull/95#issuecomment-277751517) below.