### PR TITLE
Update "CA_CERTIFICATES_JAVA_VERSION" from "update.sh"

### DIFF
--- a/8-jdk/Dockerfile
+++ b/8-jdk/Dockerfile
@@ -34,12 +34,12 @@ RUN { \
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
-ENV JAVA_VERSION 8u111
-ENV JAVA_DEBIAN_VERSION 8u111-b14-2~bpo8+1
+ENV JAVA_VERSION 8u121
+ENV JAVA_DEBIAN_VERSION 8u121-b13-1~bpo8+1
 
 # see https://bugs.debian.org/775775
 # and https://github.com/docker-library/java/issues/19#issuecomment-70546872
-ENV CA_CERTIFICATES_JAVA_VERSION 20140324
+ENV CA_CERTIFICATES_JAVA_VERSION 20161107~bpo8+1
 
 RUN set -x \
 	&& apt-get update \

--- a/8-jre/Dockerfile
+++ b/8-jre/Dockerfile
@@ -34,12 +34,12 @@ RUN { \
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/jre
 
-ENV JAVA_VERSION 8u111
-ENV JAVA_DEBIAN_VERSION 8u111-b14-2~bpo8+1
+ENV JAVA_VERSION 8u121
+ENV JAVA_DEBIAN_VERSION 8u121-b13-1~bpo8+1
 
 # see https://bugs.debian.org/775775
 # and https://github.com/docker-library/java/issues/19#issuecomment-70546872
-ENV CA_CERTIFICATES_JAVA_VERSION 20140324
+ENV CA_CERTIFICATES_JAVA_VERSION 20161107~bpo8+1
 
 RUN set -x \
 	&& apt-get update \

--- a/9-jdk/Dockerfile
+++ b/9-jdk/Dockerfile
@@ -34,8 +34,8 @@ RUN { \
 
 ENV JAVA_HOME /usr/lib/jvm/java-9-openjdk-amd64
 
-ENV JAVA_VERSION 9~b154
-ENV JAVA_DEBIAN_VERSION 9~b154-1
+ENV JAVA_VERSION 9~b155
+ENV JAVA_DEBIAN_VERSION 9~b155-1
 
 RUN set -x \
 	&& apt-get update \

--- a/9-jre/Dockerfile
+++ b/9-jre/Dockerfile
@@ -34,8 +34,8 @@ RUN { \
 
 ENV JAVA_HOME /usr/lib/jvm/java-9-openjdk-amd64
 
-ENV JAVA_VERSION 9~b154
-ENV JAVA_DEBIAN_VERSION 9~b154-1
+ENV JAVA_VERSION 9~b155
+ENV JAVA_DEBIAN_VERSION 9~b155-1
 
 RUN set -x \
 	&& apt-get update \


### PR DESCRIPTION
This adds a few seconds extra to the runtime, but should always generate the correct version number (rather than continuing to hard-code the version number).

Closes https://github.com/docker-library/openjdk/pull/95
Closes https://github.com/docker-library/openjdk/pull/97