### PR TITLE
Use "update-alternatives" to ensure that the version of OpenJDK we install stays the provider of "/usr/bin/java"

### DIFF
--- a/6-jdk/Dockerfile
+++ b/6-jdk/Dockerfile
@@ -35,12 +35,21 @@ ENV JAVA_HOME /usr/lib/jvm/java-6-openjdk-amd64
 ENV JAVA_VERSION 6b38
 ENV JAVA_DEBIAN_VERSION 6b38-1.13.10-1~deb7u1
 
-RUN set -x \
-	&& apt-get update \
-	&& apt-get install -y \
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y \
 		openjdk-6-jdk="$JAVA_DEBIAN_VERSION" \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& [ "$JAVA_HOME" = "$(docker-java-home)" ]
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+# verify that "docker-java-home" returns what we expect
+	[ "$JAVA_HOME" = "$(docker-java-home)" ]; \
+	\
+# update-alternatives so that future installs of other OpenJDK versions don't change /usr/bin/java
+	update-alternatives --get-selections | awk -v home="$JAVA_HOME" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
+# ... and verify that it actually worked for one of the alternatives we care about
+	update-alternatives --query java | grep -q 'Status: manual'
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!

--- a/6-jre/Dockerfile
+++ b/6-jre/Dockerfile
@@ -35,12 +35,21 @@ ENV JAVA_HOME /usr/lib/jvm/java-6-openjdk-amd64/jre
 ENV JAVA_VERSION 6b38
 ENV JAVA_DEBIAN_VERSION 6b38-1.13.10-1~deb7u1
 
-RUN set -x \
-	&& apt-get update \
-	&& apt-get install -y \
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y \
 		openjdk-6-jre-headless="$JAVA_DEBIAN_VERSION" \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& [ "$JAVA_HOME" = "$(docker-java-home)" ]
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+# verify that "docker-java-home" returns what we expect
+	[ "$JAVA_HOME" = "$(docker-java-home)" ]; \
+	\
+# update-alternatives so that future installs of other OpenJDK versions don't change /usr/bin/java
+	update-alternatives --get-selections | awk -v home="$JAVA_HOME" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
+# ... and verify that it actually worked for one of the alternatives we care about
+	update-alternatives --query java | grep -q 'Status: manual'
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!

--- a/7-jdk/Dockerfile
+++ b/7-jdk/Dockerfile
@@ -35,12 +35,21 @@ ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
 ENV JAVA_VERSION 7u121
 ENV JAVA_DEBIAN_VERSION 7u121-2.6.8-2~deb8u1
 
-RUN set -x \
-	&& apt-get update \
-	&& apt-get install -y \
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y \
 		openjdk-7-jdk="$JAVA_DEBIAN_VERSION" \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& [ "$JAVA_HOME" = "$(docker-java-home)" ]
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+# verify that "docker-java-home" returns what we expect
+	[ "$JAVA_HOME" = "$(docker-java-home)" ]; \
+	\
+# update-alternatives so that future installs of other OpenJDK versions don't change /usr/bin/java
+	update-alternatives --get-selections | awk -v home="$JAVA_HOME" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
+# ... and verify that it actually worked for one of the alternatives we care about
+	update-alternatives --query java | grep -q 'Status: manual'
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!

--- a/7-jre/Dockerfile
+++ b/7-jre/Dockerfile
@@ -35,12 +35,21 @@ ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64/jre
 ENV JAVA_VERSION 7u121
 ENV JAVA_DEBIAN_VERSION 7u121-2.6.8-2~deb8u1
 
-RUN set -x \
-	&& apt-get update \
-	&& apt-get install -y \
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y \
 		openjdk-7-jre-headless="$JAVA_DEBIAN_VERSION" \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& [ "$JAVA_HOME" = "$(docker-java-home)" ]
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+# verify that "docker-java-home" returns what we expect
+	[ "$JAVA_HOME" = "$(docker-java-home)" ]; \
+	\
+# update-alternatives so that future installs of other OpenJDK versions don't change /usr/bin/java
+	update-alternatives --get-selections | awk -v home="$JAVA_HOME" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
+# ... and verify that it actually worked for one of the alternatives we care about
+	update-alternatives --query java | grep -q 'Status: manual'
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!

--- a/8-jdk/Dockerfile
+++ b/8-jdk/Dockerfile
@@ -41,13 +41,22 @@ ENV JAVA_DEBIAN_VERSION 8u121-b13-1~bpo8+1
 # and https://github.com/docker-library/java/issues/19#issuecomment-70546872
 ENV CA_CERTIFICATES_JAVA_VERSION 20161107~bpo8+1
 
-RUN set -x \
-	&& apt-get update \
-	&& apt-get install -y \
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y \
 		openjdk-8-jdk="$JAVA_DEBIAN_VERSION" \
 		ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& [ "$JAVA_HOME" = "$(docker-java-home)" ]
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+# verify that "docker-java-home" returns what we expect
+	[ "$JAVA_HOME" = "$(docker-java-home)" ]; \
+	\
+# update-alternatives so that future installs of other OpenJDK versions don't change /usr/bin/java
+	update-alternatives --get-selections | awk -v home="$JAVA_HOME" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
+# ... and verify that it actually worked for one of the alternatives we care about
+	update-alternatives --query java | grep -q 'Status: manual'
 
 # see CA_CERTIFICATES_JAVA_VERSION notes above
 RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure

--- a/8-jre/Dockerfile
+++ b/8-jre/Dockerfile
@@ -41,13 +41,22 @@ ENV JAVA_DEBIAN_VERSION 8u121-b13-1~bpo8+1
 # and https://github.com/docker-library/java/issues/19#issuecomment-70546872
 ENV CA_CERTIFICATES_JAVA_VERSION 20161107~bpo8+1
 
-RUN set -x \
-	&& apt-get update \
-	&& apt-get install -y \
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y \
 		openjdk-8-jre-headless="$JAVA_DEBIAN_VERSION" \
 		ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& [ "$JAVA_HOME" = "$(docker-java-home)" ]
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+# verify that "docker-java-home" returns what we expect
+	[ "$JAVA_HOME" = "$(docker-java-home)" ]; \
+	\
+# update-alternatives so that future installs of other OpenJDK versions don't change /usr/bin/java
+	update-alternatives --get-selections | awk -v home="$JAVA_HOME" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
+# ... and verify that it actually worked for one of the alternatives we care about
+	update-alternatives --query java | grep -q 'Status: manual'
 
 # see CA_CERTIFICATES_JAVA_VERSION notes above
 RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure

--- a/9-jdk/Dockerfile
+++ b/9-jdk/Dockerfile
@@ -37,12 +37,21 @@ ENV JAVA_HOME /usr/lib/jvm/java-9-openjdk-amd64
 ENV JAVA_VERSION 9~b161
 ENV JAVA_DEBIAN_VERSION 9~b161-1
 
-RUN set -x \
-	&& apt-get update \
-	&& apt-get install -y \
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y \
 		openjdk-9-jdk-headless="$JAVA_DEBIAN_VERSION" \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& [ "$JAVA_HOME" = "$(docker-java-home)" ]
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+# verify that "docker-java-home" returns what we expect
+	[ "$JAVA_HOME" = "$(docker-java-home)" ]; \
+	\
+# update-alternatives so that future installs of other OpenJDK versions don't change /usr/bin/java
+	update-alternatives --get-selections | awk -v home="$JAVA_HOME" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
+# ... and verify that it actually worked for one of the alternatives we care about
+	update-alternatives --query java | grep -q 'Status: manual'
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!

--- a/9-jre/Dockerfile
+++ b/9-jre/Dockerfile
@@ -37,12 +37,21 @@ ENV JAVA_HOME /usr/lib/jvm/java-9-openjdk-amd64
 ENV JAVA_VERSION 9~b161
 ENV JAVA_DEBIAN_VERSION 9~b161-1
 
-RUN set -x \
-	&& apt-get update \
-	&& apt-get install -y \
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y \
 		openjdk-9-jre-headless="$JAVA_DEBIAN_VERSION" \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& [ "$JAVA_HOME" = "$(docker-java-home)" ]
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+# verify that "docker-java-home" returns what we expect
+	[ "$JAVA_HOME" = "$(docker-java-home)" ]; \
+	\
+# update-alternatives so that future installs of other OpenJDK versions don't change /usr/bin/java
+	update-alternatives --get-selections | awk -v home="$JAVA_HOME" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
+# ... and verify that it actually worked for one of the alternatives we care about
+	update-alternatives --query java | grep -q 'Status: manual'
 
 # If you're reading this and have any feedback on how this image could be
 #   improved, please open an issue or a pull request so we can discuss it!


### PR DESCRIPTION
Closes #110