### PR TITLE
Use some fancy symlinking to create a Dockerfile that works on other architectures too

### DIFF
--- a/6-jdk/Dockerfile
+++ b/6-jdk/Dockerfile
@@ -30,7 +30,9 @@ RUN { \
 	} > /usr/local/bin/docker-java-home \
 	&& chmod +x /usr/local/bin/docker-java-home
 
-ENV JAVA_HOME /usr/lib/jvm/java-6-openjdk-amd64
+# do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
+RUN ln -svT "/usr/lib/jvm/java-6-openjdk-$(dpkg --print-architecture)" /docker-java-home
+ENV JAVA_HOME /docker-java-home
 
 ENV JAVA_VERSION 6b38
 ENV JAVA_DEBIAN_VERSION 6b38-1.13.10-1~deb7u1
@@ -44,10 +46,10 @@ RUN set -ex; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
 # verify that "docker-java-home" returns what we expect
-	[ "$JAVA_HOME" = "$(docker-java-home)" ]; \
+	[ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ]; \
 	\
 # update-alternatives so that future installs of other OpenJDK versions don't change /usr/bin/java
-	update-alternatives --get-selections | awk -v home="$JAVA_HOME" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
+	update-alternatives --get-selections | awk -v home="$(readlink -f "$JAVA_HOME")" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
 # ... and verify that it actually worked for one of the alternatives we care about
 	update-alternatives --query java | grep -q 'Status: manual'
 

--- a/6-jre/Dockerfile
+++ b/6-jre/Dockerfile
@@ -30,7 +30,9 @@ RUN { \
 	} > /usr/local/bin/docker-java-home \
 	&& chmod +x /usr/local/bin/docker-java-home
 
-ENV JAVA_HOME /usr/lib/jvm/java-6-openjdk-amd64/jre
+# do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
+RUN ln -svT "/usr/lib/jvm/java-6-openjdk-$(dpkg --print-architecture)" /docker-java-home
+ENV JAVA_HOME /docker-java-home/jre
 
 ENV JAVA_VERSION 6b38
 ENV JAVA_DEBIAN_VERSION 6b38-1.13.10-1~deb7u1
@@ -44,10 +46,10 @@ RUN set -ex; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
 # verify that "docker-java-home" returns what we expect
-	[ "$JAVA_HOME" = "$(docker-java-home)" ]; \
+	[ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ]; \
 	\
 # update-alternatives so that future installs of other OpenJDK versions don't change /usr/bin/java
-	update-alternatives --get-selections | awk -v home="$JAVA_HOME" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
+	update-alternatives --get-selections | awk -v home="$(readlink -f "$JAVA_HOME")" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
 # ... and verify that it actually worked for one of the alternatives we care about
 	update-alternatives --query java | grep -q 'Status: manual'
 

--- a/7-jdk/Dockerfile
+++ b/7-jdk/Dockerfile
@@ -30,7 +30,9 @@ RUN { \
 	} > /usr/local/bin/docker-java-home \
 	&& chmod +x /usr/local/bin/docker-java-home
 
-ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
+# do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
+RUN ln -svT "/usr/lib/jvm/java-7-openjdk-$(dpkg --print-architecture)" /docker-java-home
+ENV JAVA_HOME /docker-java-home
 
 ENV JAVA_VERSION 7u121
 ENV JAVA_DEBIAN_VERSION 7u121-2.6.8-2~deb8u1
@@ -44,10 +46,10 @@ RUN set -ex; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
 # verify that "docker-java-home" returns what we expect
-	[ "$JAVA_HOME" = "$(docker-java-home)" ]; \
+	[ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ]; \
 	\
 # update-alternatives so that future installs of other OpenJDK versions don't change /usr/bin/java
-	update-alternatives --get-selections | awk -v home="$JAVA_HOME" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
+	update-alternatives --get-selections | awk -v home="$(readlink -f "$JAVA_HOME")" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
 # ... and verify that it actually worked for one of the alternatives we care about
 	update-alternatives --query java | grep -q 'Status: manual'
 

--- a/7-jre/Dockerfile
+++ b/7-jre/Dockerfile
@@ -30,7 +30,9 @@ RUN { \
 	} > /usr/local/bin/docker-java-home \
 	&& chmod +x /usr/local/bin/docker-java-home
 
-ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64/jre
+# do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
+RUN ln -svT "/usr/lib/jvm/java-7-openjdk-$(dpkg --print-architecture)" /docker-java-home
+ENV JAVA_HOME /docker-java-home/jre
 
 ENV JAVA_VERSION 7u121
 ENV JAVA_DEBIAN_VERSION 7u121-2.6.8-2~deb8u1
@@ -44,10 +46,10 @@ RUN set -ex; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
 # verify that "docker-java-home" returns what we expect
-	[ "$JAVA_HOME" = "$(docker-java-home)" ]; \
+	[ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ]; \
 	\
 # update-alternatives so that future installs of other OpenJDK versions don't change /usr/bin/java
-	update-alternatives --get-selections | awk -v home="$JAVA_HOME" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
+	update-alternatives --get-selections | awk -v home="$(readlink -f "$JAVA_HOME")" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
 # ... and verify that it actually worked for one of the alternatives we care about
 	update-alternatives --query java | grep -q 'Status: manual'
 

--- a/8-jdk/Dockerfile
+++ b/8-jdk/Dockerfile
@@ -32,7 +32,9 @@ RUN { \
 	} > /usr/local/bin/docker-java-home \
 	&& chmod +x /usr/local/bin/docker-java-home
 
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+# do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
+RUN ln -svT "/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)" /docker-java-home
+ENV JAVA_HOME /docker-java-home
 
 ENV JAVA_VERSION 8u121
 ENV JAVA_DEBIAN_VERSION 8u121-b13-1~bpo8+1
@@ -51,10 +53,10 @@ RUN set -ex; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
 # verify that "docker-java-home" returns what we expect
-	[ "$JAVA_HOME" = "$(docker-java-home)" ]; \
+	[ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ]; \
 	\
 # update-alternatives so that future installs of other OpenJDK versions don't change /usr/bin/java
-	update-alternatives --get-selections | awk -v home="$JAVA_HOME" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
+	update-alternatives --get-selections | awk -v home="$(readlink -f "$JAVA_HOME")" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
 # ... and verify that it actually worked for one of the alternatives we care about
 	update-alternatives --query java | grep -q 'Status: manual'
 

--- a/8-jre/Dockerfile
+++ b/8-jre/Dockerfile
@@ -32,7 +32,9 @@ RUN { \
 	} > /usr/local/bin/docker-java-home \
 	&& chmod +x /usr/local/bin/docker-java-home
 
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/jre
+# do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
+RUN ln -svT "/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)" /docker-java-home
+ENV JAVA_HOME /docker-java-home/jre
 
 ENV JAVA_VERSION 8u121
 ENV JAVA_DEBIAN_VERSION 8u121-b13-1~bpo8+1
@@ -51,10 +53,10 @@ RUN set -ex; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
 # verify that "docker-java-home" returns what we expect
-	[ "$JAVA_HOME" = "$(docker-java-home)" ]; \
+	[ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ]; \
 	\
 # update-alternatives so that future installs of other OpenJDK versions don't change /usr/bin/java
-	update-alternatives --get-selections | awk -v home="$JAVA_HOME" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
+	update-alternatives --get-selections | awk -v home="$(readlink -f "$JAVA_HOME")" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
 # ... and verify that it actually worked for one of the alternatives we care about
 	update-alternatives --query java | grep -q 'Status: manual'
 

--- a/9-jdk/Dockerfile
+++ b/9-jdk/Dockerfile
@@ -32,7 +32,9 @@ RUN { \
 	} > /usr/local/bin/docker-java-home \
 	&& chmod +x /usr/local/bin/docker-java-home
 
-ENV JAVA_HOME /usr/lib/jvm/java-9-openjdk-amd64
+# do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
+RUN ln -svT "/usr/lib/jvm/java-9-openjdk-$(dpkg --print-architecture)" /docker-java-home
+ENV JAVA_HOME /docker-java-home
 
 ENV JAVA_VERSION 9~b161
 ENV JAVA_DEBIAN_VERSION 9~b161-1
@@ -46,10 +48,10 @@ RUN set -ex; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
 # verify that "docker-java-home" returns what we expect
-	[ "$JAVA_HOME" = "$(docker-java-home)" ]; \
+	[ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ]; \
 	\
 # update-alternatives so that future installs of other OpenJDK versions don't change /usr/bin/java
-	update-alternatives --get-selections | awk -v home="$JAVA_HOME" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
+	update-alternatives --get-selections | awk -v home="$(readlink -f "$JAVA_HOME")" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
 # ... and verify that it actually worked for one of the alternatives we care about
 	update-alternatives --query java | grep -q 'Status: manual'
 

--- a/9-jre/Dockerfile
+++ b/9-jre/Dockerfile
@@ -32,7 +32,9 @@ RUN { \
 	} > /usr/local/bin/docker-java-home \
 	&& chmod +x /usr/local/bin/docker-java-home
 
-ENV JAVA_HOME /usr/lib/jvm/java-9-openjdk-amd64
+# do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
+RUN ln -svT "/usr/lib/jvm/java-9-openjdk-$(dpkg --print-architecture)" /docker-java-home
+ENV JAVA_HOME /docker-java-home
 
 ENV JAVA_VERSION 9~b161
 ENV JAVA_DEBIAN_VERSION 9~b161-1
@@ -46,10 +48,10 @@ RUN set -ex; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
 # verify that "docker-java-home" returns what we expect
-	[ "$JAVA_HOME" = "$(docker-java-home)" ]; \
+	[ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ]; \
 	\
 # update-alternatives so that future installs of other OpenJDK versions don't change /usr/bin/java
-	update-alternatives --get-selections | awk -v home="$JAVA_HOME" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
+	update-alternatives --get-selections | awk -v home="$(readlink -f "$JAVA_HOME")" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
 # ... and verify that it actually worked for one of the alternatives we care about
 	update-alternatives --query java | grep -q 'Status: manual'
 


### PR DESCRIPTION
Tested by swapping `FROM buildpack-deps:jessie-curl` for `FROM s390x/buildpack-deps:jessie-curl` and building on an `s390x` machine (which was successful).