### PR TITLE
Use debian 9 "stretch" as base image

### DIFF
--- a/8-jdk/Dockerfile
+++ b/8-jdk/Dockerfile
@@ -17,8 +17,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		xz-utils \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN echo 'deb http://deb.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list
-
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
@@ -37,11 +35,11 @@ RUN ln -svT "/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)" /docker-j
 ENV JAVA_HOME /docker-java-home
 
 ENV JAVA_VERSION 8u131
-ENV JAVA_DEBIAN_VERSION 8u131-b11-1~bpo8+1
+ENV JAVA_DEBIAN_VERSION 8u131-b11-2
 
 # see https://bugs.debian.org/775775
 # and https://github.com/docker-library/java/issues/19#issuecomment-70546872
-ENV CA_CERTIFICATES_JAVA_VERSION 20161107~bpo8+1
+ENV CA_CERTIFICATES_JAVA_VERSION 20170531+nmu1
 
 RUN set -ex; \
 	\

--- a/8-jdk/Dockerfile
+++ b/8-jdk/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:jessie-scm
+FROM buildpack-deps:stretch-scm
 
 # A few problems with compiling Java from source:
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.

--- a/8-jre/Dockerfile
+++ b/8-jre/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:jessie-curl
+FROM buildpack-deps:stretch-curl
 
 # A few problems with compiling Java from source:
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.
@@ -16,8 +16,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		unzip \
 		xz-utils \
 	&& rm -rf /var/lib/apt/lists/*
-
-RUN echo 'deb http://deb.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list
 
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
@@ -37,11 +35,11 @@ RUN ln -svT "/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)" /docker-j
 ENV JAVA_HOME /docker-java-home/jre
 
 ENV JAVA_VERSION 8u131
-ENV JAVA_DEBIAN_VERSION 8u131-b11-1~bpo8+1
+ENV JAVA_DEBIAN_VERSION 8u131-b11-2
 
 # see https://bugs.debian.org/775775
 # and https://github.com/docker-library/java/issues/19#issuecomment-70546872
-ENV CA_CERTIFICATES_JAVA_VERSION 20161107~bpo8+1
+ENV CA_CERTIFICATES_JAVA_VERSION 20170531+nmu1
 
 RUN set -ex; \
 	\

--- a/update.sh
+++ b/update.sh
@@ -12,7 +12,7 @@ versions=( "${versions[@]%/}" )
 declare -A suites=(
 	[6]='wheezy'
 	[7]='jessie'
-	[8]='jessie'
+	[8]='stretch'
 	[9]='sid'
 )
 declare -A alpineVersions=(
@@ -22,7 +22,6 @@ declare -A alpineVersions=(
 )
 
 declare -A addSuites=(
-	[8]='jessie-backports'
 	[9]='experimental'
 )
 


### PR DESCRIPTION
jessie do bundle outdated dependencies, see https://github.com/jenkinsci/docker/issues/519