### PR TITLE
Add ojdk 9 for windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,6 +3,10 @@ image: Visual Studio 2017
 
 environment:
   matrix:
+    - version: 9-jdk
+      variant: windowsservercore
+    - version: 9-jdk
+      variant: nanoserver
     - version: 8-jdk
       variant: windowsservercore
     - version: 8-jdk

--- a/9-jdk/Dockerfile
+++ b/9-jdk/Dockerfile
@@ -36,7 +36,7 @@ RUN { \
 RUN ln -svT "/usr/lib/jvm/java-9-openjdk-$(dpkg --print-architecture)" /docker-java-home
 ENV JAVA_HOME /docker-java-home
 
-ENV JAVA_VERSION 9~b177
+ENV JAVA_VERSION 9-b177
 ENV JAVA_DEBIAN_VERSION 9~b177-3
 
 RUN set -ex; \

--- a/9-jdk/windows/nanoserver/Dockerfile
+++ b/9-jdk/windows/nanoserver/Dockerfile
@@ -1,0 +1,43 @@
+FROM microsoft/nanoserver
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV JAVA_HOME C:\\ojdkbuild
+RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+# Nano Server does not have "[Environment]::SetEnvironmentVariable()"
+	setx /M PATH $newPath;
+
+# https://github.com/ojdkbuild/ojdkbuild/releases
+ENV JAVA_VERSION 9
+ENV JAVA_OJDKBUILD_VERSION 9-ea-b154-1
+ENV JAVA_OJDKBUILD_ZIP java-9-openjdk-9.0.0-1.b154.ojdkbuildea.windows.x86_64.zip
+ENV JAVA_OJDKBUILD_SHA256 bb0177ada6d4061b1223882db20ba04f3f39c3da7dd695a1e1004e93a65fcfd6
+
+RUN $url = ('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/{1}' -f $env:JAVA_OJDKBUILD_VERSION, $env:JAVA_OJDKBUILD_ZIP); \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	Invoke-WebRequest -Uri $url -OutFile 'ojdkbuild.zip'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_OJDKBUILD_SHA256); \
+	if ((Get-FileHash ojdkbuild.zip -Algorithm sha256).Hash -ne $env:JAVA_OJDKBUILD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive ojdkbuild.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Renaming ...'; \
+	Move-Item \
+		-Path ('C:\{0}' -f ($env:JAVA_OJDKBUILD_ZIP -Replace '.zip$', '')) \
+		-Destination $env:JAVA_HOME \
+	; \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  java -version'; java -version; \
+	Write-Host '  javac -version'; javac -version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item ojdkbuild.zip -Force; \
+	\
+	Write-Host 'Complete.';

--- a/9-jdk/windows/nanoserver/Dockerfile
+++ b/9-jdk/windows/nanoserver/Dockerfile
@@ -10,7 +10,7 @@ RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
 	setx /M PATH $newPath;
 
 # https://github.com/ojdkbuild/ojdkbuild/releases
-ENV JAVA_VERSION 9
+ENV JAVA_VERSION 9-b154
 ENV JAVA_OJDKBUILD_VERSION 9-ea-b154-1
 ENV JAVA_OJDKBUILD_ZIP java-9-openjdk-9.0.0-1.b154.ojdkbuildea.windows.x86_64.zip
 ENV JAVA_OJDKBUILD_SHA256 bb0177ada6d4061b1223882db20ba04f3f39c3da7dd695a1e1004e93a65fcfd6

--- a/9-jdk/windows/windowsservercore/Dockerfile
+++ b/9-jdk/windows/windowsservercore/Dockerfile
@@ -1,0 +1,43 @@
+FROM microsoft/windowsservercore
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV JAVA_HOME C:\\ojdkbuild
+RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+# Nano Server does not have "[Environment]::SetEnvironmentVariable()"
+	setx /M PATH $newPath;
+
+# https://github.com/ojdkbuild/ojdkbuild/releases
+ENV JAVA_VERSION 9
+ENV JAVA_OJDKBUILD_VERSION 9-ea-b154-1
+ENV JAVA_OJDKBUILD_ZIP java-9-openjdk-9.0.0-1.b154.ojdkbuildea.windows.x86_64.zip
+ENV JAVA_OJDKBUILD_SHA256 bb0177ada6d4061b1223882db20ba04f3f39c3da7dd695a1e1004e93a65fcfd6
+
+RUN $url = ('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/{1}' -f $env:JAVA_OJDKBUILD_VERSION, $env:JAVA_OJDKBUILD_ZIP); \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	Invoke-WebRequest -Uri $url -OutFile 'ojdkbuild.zip'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_OJDKBUILD_SHA256); \
+	if ((Get-FileHash ojdkbuild.zip -Algorithm sha256).Hash -ne $env:JAVA_OJDKBUILD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive ojdkbuild.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Renaming ...'; \
+	Move-Item \
+		-Path ('C:\{0}' -f ($env:JAVA_OJDKBUILD_ZIP -Replace '.zip$', '')) \
+		-Destination $env:JAVA_HOME \
+	; \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  java -version'; java -version; \
+	Write-Host '  javac -version'; javac -version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item ojdkbuild.zip -Force; \
+	\
+	Write-Host 'Complete.';

--- a/9-jdk/windows/windowsservercore/Dockerfile
+++ b/9-jdk/windows/windowsservercore/Dockerfile
@@ -10,7 +10,7 @@ RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
 	setx /M PATH $newPath;
 
 # https://github.com/ojdkbuild/ojdkbuild/releases
-ENV JAVA_VERSION 9
+ENV JAVA_VERSION 9-b154
 ENV JAVA_OJDKBUILD_VERSION 9-ea-b154-1
 ENV JAVA_OJDKBUILD_ZIP java-9-openjdk-9.0.0-1.b154.ojdkbuildea.windows.x86_64.zip
 ENV JAVA_OJDKBUILD_SHA256 bb0177ada6d4061b1223882db20ba04f3f39c3da7dd695a1e1004e93a65fcfd6

--- a/9-jre/Dockerfile
+++ b/9-jre/Dockerfile
@@ -36,7 +36,7 @@ RUN { \
 RUN ln -svT "/usr/lib/jvm/java-9-openjdk-$(dpkg --print-architecture)" /docker-java-home
 ENV JAVA_HOME /docker-java-home
 
-ENV JAVA_VERSION 9~b177
+ENV JAVA_VERSION 9-b177
 ENV JAVA_DEBIAN_VERSION 9~b177-3
 
 RUN set -ex; \

--- a/update.sh
+++ b/update.sh
@@ -150,6 +150,8 @@ for version in "${versions[@]}"; do
 	debianVersion="$(debian-latest-version "$debianPackage" "$debSuite")"
 	fullVersion="${debianVersion%%-*}"
 	fullVersion="${fullVersion#*:}"
+	tilde='~'
+	fullVersion="${fullVersion//$tilde/-}"
 
 	echo "$version: $fullVersion (debian $debianVersion)"
 
@@ -351,7 +353,14 @@ EOD
 			echo >&2 "error: $ojdkbuildVersion seems to have $ojdkbuildZip, but no sha256 for it"
 			exit 1
 		fi
-		ojdkJavaVersion="$(echo "$ojdkbuildVersion" | cut -d. -f2,4 | cut -d- -f1 | tr . u)" # convert "1.8.0.111-3" into "8u111"
+
+		if [[ "$ojdkbuildVersion" == *-ea-* ]]; then
+			# convert "9-ea-b154-1" into "9-b154"
+			ojdkJavaVersion="$(echo "$ojdkbuildVersion" | sed -r 's/-ea-/-/' | cut -d- -f1,2)"
+		else
+			# convert "1.8.0.111-3" into "8u111"
+			ojdkJavaVersion="$(echo "$ojdkbuildVersion" | cut -d. -f2,4 | cut -d- -f1 | tr . u)"
+		fi
 
 		echo "$version: $ojdkJavaVersion (windows ojdkbuild $ojdkbuildVersion)"
 

--- a/update.sh
+++ b/update.sh
@@ -329,7 +329,7 @@ EOD
 		ojdkbuildVersion="$(
 			git ls-remote --tags 'https://github.com/ojdkbuild/ojdkbuild' \
 				| cut -d/ -f3 \
-				| grep -E '^1[.]'"$javaVersion"'[.]' \
+				| grep -E '^(1[.])?'"$javaVersion"'[.-]' \
 				| sort -V \
 				| tail -1
 		)"
@@ -339,7 +339,7 @@ EOD
 		fi
 		ojdkbuildZip="$(
 			curl -fsSL "https://github.com/ojdkbuild/ojdkbuild/releases/tag/$ojdkbuildVersion" \
-				| grep --only-matching -E 'java-'"$(echo "$ojdkbuildVersion" | cut -d. -f1-3)"'-openjdk-'"$ojdkbuildVersion"'[.][b0-9]+[.]ojdkbuild[.]windows[.]x86_64[.]zip' \
+				| grep --only-matching -E 'java-[0-9.]+-openjdk-[b0-9.-]+[.]ojdkbuild(ea)?[.]windows[.]x86_64[.]zip' \
 				| sort -u
 		)"
 		if [ -z "$ojdkbuildZip" ]; then


### PR DESCRIPTION
https://github.com/ojdkbuild/ojdkbuild/releases java-9-openjdk-9.0.0-1.b154.ea: published Mar 2 :astonished: 

```console
Docker@offcl-img-test MINGW64 ~/docker/openjdk (windows-jdk9)
$ docker build 9-jdk/windows/nanoserver/
Sending build context to Docker daemon 3.584 kB
Step 1/9 : FROM microsoft/nanoserver
 ---> 9473d5d31d36
Step 2/9 : SHELL powershell -Command $ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';
 ---> Using cache
 ---> 5b1ae62aa856
Step 3/9 : ENV JAVA_HOME C:\\ojdkbuild
 ---> Using cache
 ---> e69659beb13c
Step 4/9 : RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH);         Write-Host ('Updating PATH: {0}' -f $newPath);       setx /M PATH $newPath;
 ---> Using cache
 ---> 6ab7945c0f89
Step 5/9 : ENV JAVA_VERSION 9
 ---> Running in 1021a41f31ca
 ---> 8d13f6aae4a1
Removing intermediate container 1021a41f31ca
Step 6/9 : ENV JAVA_OJDKBUILD_VERSION 9-ea-b154-1
 ---> Running in 018f7ef7752f
 ---> a1b6142591e5
Removing intermediate container 018f7ef7752f
Step 7/9 : ENV JAVA_OJDKBUILD_ZIP java-9-openjdk-9.0.0-1.b154.ojdkbuildea.windows.x86_64.zip
 ---> Running in 43090da2217e
 ---> 62be36b1a94c
Removing intermediate container 43090da2217e
Step 8/9 : ENV JAVA_OJDKBUILD_SHA256 bb0177ada6d4061b1223882db20ba04f3f39c3da7dd695a1e1004e93a65fcfd6
 ---> Running in 1bae7f8bb668
 ---> 1e926879f289
Removing intermediate container 1bae7f8bb668
Step 9/9 : RUN $url = ('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/{1}' -f $env:JAVA_OJDKBUILD_VERSION, $env:JAVA_OJDKBUILD_ZIP);  Write-Host ('Downloading {0} ...' -f $url);     Invoke-WebRequest -Uri $url -OutFile 'ojdkbuild.zip';        Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_OJDKBUILD_SHA256);     if ((Get-FileHash ojdkbuild.zip -Algorithm sha256).Hash -ne $env:JAVA_OJDKBUILD_SHA256) {           Write-Host 'FAILED!';            exit 1;         };              Write-Host 'Expanding ...';     Expand-Archive ojdkbuild.zip -DestinationPath C:\;           Write-Host 'Renaming ...';      Move-Item               -Path ('C:\{0}' -f ($env:JAVA_OJDKBUILD_ZIP -Replace '.zip$', ''))           -Destination $env:JAVA_HOME     ;   Write-Host 'Verifying install ...';      Write-Host '  java -version'; java -version;    Write-Host '  javac -version'; javac -version;               Write-Host 'Removing ...';      Remove-Item ojdkbuild.zip -Force;   Write-Host 'Complete.';
 ---> Running in ca8a59d80b72
Downloading https://github.com/ojdkbuild/ojdkbuild/releases/download/9-ea-b154-1/java-9-openjdk-9.0.0-1.b154.ojdkbuildea.windows.x86_64.zip ...
Verifying sha256 (bb0177ada6d4061b1223882db20ba04f3f39c3da7dd695a1e1004e93a65fcfd6) ...
Expanding ...
Renaming ...
Verifying install ...
 java -version
openjdk version "9.0.0.1-ojdkbuildea"
OpenJDK Runtime Environment (build 9.0.0.1-ojdkbuildea+154)
OpenJDK 64-Bit Server VM (build 9.0.0.1-ojdkbuildea+154, mixed mode)
 javac -version
javac 9.0.0.1-ojdkbuildea
Removing ...
Complete.
 ---> a6af7de184be
Removing intermediate container ca8a59d80b72
Successfully built a6af7de184be

Docker@offcl-img-test MINGW64 ~/docker/openjdk (windows-jdk9)
$ docker build 9-jdk/windows/windowsservercore/
Sending build context to Docker daemon 3.584 kB
Step 1/9 : FROM microsoft/windowsservercore
 ---> 2c42a1b4dea8
Step 2/9 : SHELL powershell -Command $ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';
 ---> Using cache
 ---> 7cefb1895e87
Step 3/9 : ENV JAVA_HOME C:\\ojdkbuild
 ---> Using cache
 ---> 1370305d1bcb
Step 4/9 : RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH);         Write-Host ('Updating PATH: {0}' -f $newPath);       setx /M PATH $newPath;
 ---> Using cache
 ---> 0f1d937237df
Step 5/9 : ENV JAVA_VERSION 9
 ---> Running in b1d48dc4fee5
 ---> 6a2908929207
Removing intermediate container b1d48dc4fee5
Step 6/9 : ENV JAVA_OJDKBUILD_VERSION 9-ea-b154-1
 ---> Running in c531e7305ba9
 ---> 3d2c066e6030
Removing intermediate container c531e7305ba9
Step 7/9 : ENV JAVA_OJDKBUILD_ZIP java-9-openjdk-9.0.0-1.b154.ojdkbuildea.windows.x86_64.zip
 ---> Running in c15a02968f9c
 ---> 50cd74f01e97
Removing intermediate container c15a02968f9c
Step 8/9 : ENV JAVA_OJDKBUILD_SHA256 bb0177ada6d4061b1223882db20ba04f3f39c3da7dd695a1e1004e93a65fcfd6
 ---> Running in 5a76605497a4
 ---> c04d596ba902
Removing intermediate container 5a76605497a4
Step 9/9 : RUN $url = ('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/{1}' -f $env:JAVA_OJDKBUILD_VERSION, $env:JAVA_OJDKBUILD_ZIP);  Write-Host ('Downloading {0} ...' -f $url);     Invoke-WebRequest -Uri $url -OutFile 'ojdkbuild.zip';        Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_OJDKBUILD_SHA256);     if ((Get-FileHash ojdkbuild.zip -Algorithm sha256).Hash -ne $env:JAVA_OJDKBUILD_SHA256) {           Write-Host 'FAILED!';            exit 1;         };              Write-Host 'Expanding ...';     Expand-Archive ojdkbuild.zip -DestinationPath C:\;           Write-Host 'Renaming ...';      Move-Item               -Path ('C:\{0}' -f ($env:JAVA_OJDKBUILD_ZIP -Replace '.zip$', ''))           -Destination $env:JAVA_HOME     ;   Write-Host 'Verifying install ...';      Write-Host '  java -version'; java -version;    Write-Host '  javac -version'; javac -version;               Write-Host 'Removing ...';      Remove-Item ojdkbuild.zip -Force;   Write-Host 'Complete.';
 ---> Running in b37c4d177a86
Downloading https://github.com/ojdkbuild/ojdkbuild/releases/download/9-ea-b154-1/java-9-openjdk-9.0.0-1.b154.ojdkbuildea.windows.x86_64.zip ...
Verifying sha256 (bb0177ada6d4061b1223882db20ba04f3f39c3da7dd695a1e1004e93a65fcfd6) ...
Expanding ...
Renaming ...
Verifying install ...
 java -version
openjdk version "9.0.0.1-ojdkbuildea"
OpenJDK Runtime Environment (build 9.0.0.1-ojdkbuildea+154)
OpenJDK 64-Bit Server VM (build 9.0.0.1-ojdkbuildea+154, mixed mode)
 javac -version
javac 9.0.0.1-ojdkbuildea
Removing ...
Complete.
 ---> 02181905ddf3
Removing intermediate container b37c4d177a86
Successfully built 02181905ddf3

```