### PR TITLE
Add slim variants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,25 @@ services: docker
 
 env:
   - VERSION=9-jre
+  - VERSION=9-jre VARIANT=slim
   - VERSION=9-jdk
+  - VERSION=9-jdk VARIANT=slim
   - VERSION=8-jre
+  - VERSION=8-jre VARIANT=slim
   - VERSION=8-jre VARIANT=alpine
   - VERSION=8-jdk
+  - VERSION=8-jdk VARIANT=slim
   - VERSION=8-jdk VARIANT=alpine
   - VERSION=7-jre
+  - VERSION=7-jre VARIANT=slim
   - VERSION=7-jre VARIANT=alpine
   - VERSION=7-jdk
+  - VERSION=7-jdk VARIANT=slim
   - VERSION=7-jdk VARIANT=alpine
   - VERSION=6-jre
+  - VERSION=6-jre VARIANT=slim
   - VERSION=6-jdk
+  - VERSION=6-jdk VARIANT=slim
 
 install:
   - git clone https://github.com/docker-library/official-images.git ~/official-images

--- a/6-jdk/Dockerfile
+++ b/6-jdk/Dockerfile
@@ -6,10 +6,15 @@
 
 FROM buildpack-deps:wheezy-scm
 
-# A few problems with compiling Java from source:
+# A few reasons for installing distribution-provided OpenJDK:
+#
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.
+#
 #  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
-#       really hairy.
+#     really hairy.
+#
+#     For some sample build times, see Debian's buildd logs:
+#       https://buildd.debian.org/status/logs.php?pkg=openjdk-6
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzip2 \
@@ -39,6 +44,11 @@ ENV JAVA_DEBIAN_VERSION 6b38-1.13.10-1~deb7u1
 
 RUN set -ex; \
 	\
+# deal with slim variants not having man page directories (which causes "update-alternatives" to fail)
+	if [ ! -d /usr/share/man/man1 ]; then \
+		mkdir -p /usr/share/man/man1; \
+	fi; \
+	\
 	apt-get update; \
 	apt-get install -y \
 		openjdk-6-jdk="$JAVA_DEBIAN_VERSION" \
@@ -54,4 +64,6 @@ RUN set -ex; \
 	update-alternatives --query java | grep -q 'Status: manual'
 
 # If you're reading this and have any feedback on how this image could be
-#   improved, please open an issue or a pull request so we can discuss it!
+# improved, please open an issue or a pull request so we can discuss it!
+#
+#   https://github.com/docker-library/openjdk/issues

--- a/6-jdk/slim/Dockerfile
+++ b/6-jdk/slim/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:stretch-curl
+FROM debian:wheezy-slim
 
 # A few reasons for installing distribution-provided OpenJDK:
 #
@@ -14,7 +14,7 @@ FROM buildpack-deps:stretch-curl
 #     really hairy.
 #
 #     For some sample build times, see Debian's buildd logs:
-#       https://buildd.debian.org/status/logs.php?pkg=openjdk-8
+#       https://buildd.debian.org/status/logs.php?pkg=openjdk-6
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzip2 \
@@ -36,15 +36,11 @@ RUN { \
 	&& chmod +x /usr/local/bin/docker-java-home
 
 # do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
-RUN ln -svT "/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)" /docker-java-home
-ENV JAVA_HOME /docker-java-home/jre
+RUN ln -svT "/usr/lib/jvm/java-6-openjdk-$(dpkg --print-architecture)" /docker-java-home
+ENV JAVA_HOME /docker-java-home
 
-ENV JAVA_VERSION 8u131
-ENV JAVA_DEBIAN_VERSION 8u131-b11-2
-
-# see https://bugs.debian.org/775775
-# and https://github.com/docker-library/java/issues/19#issuecomment-70546872
-ENV CA_CERTIFICATES_JAVA_VERSION 20170531+nmu1
+ENV JAVA_VERSION 6b38
+ENV JAVA_DEBIAN_VERSION 6b38-1.13.10-1~deb7u1
 
 RUN set -ex; \
 	\
@@ -55,8 +51,7 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y \
-		openjdk-8-jre-headless="$JAVA_DEBIAN_VERSION" \
-		ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
+		openjdk-6-jdk="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
@@ -67,9 +62,6 @@ RUN set -ex; \
 	update-alternatives --get-selections | awk -v home="$(readlink -f "$JAVA_HOME")" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
 # ... and verify that it actually worked for one of the alternatives we care about
 	update-alternatives --query java | grep -q 'Status: manual'
-
-# see CA_CERTIFICATES_JAVA_VERSION notes above
-RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
 
 # If you're reading this and have any feedback on how this image could be
 # improved, please open an issue or a pull request so we can discuss it!

--- a/6-jre/Dockerfile
+++ b/6-jre/Dockerfile
@@ -6,10 +6,15 @@
 
 FROM buildpack-deps:wheezy-curl
 
-# A few problems with compiling Java from source:
+# A few reasons for installing distribution-provided OpenJDK:
+#
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.
+#
 #  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
-#       really hairy.
+#     really hairy.
+#
+#     For some sample build times, see Debian's buildd logs:
+#       https://buildd.debian.org/status/logs.php?pkg=openjdk-6
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzip2 \
@@ -39,6 +44,11 @@ ENV JAVA_DEBIAN_VERSION 6b38-1.13.10-1~deb7u1
 
 RUN set -ex; \
 	\
+# deal with slim variants not having man page directories (which causes "update-alternatives" to fail)
+	if [ ! -d /usr/share/man/man1 ]; then \
+		mkdir -p /usr/share/man/man1; \
+	fi; \
+	\
 	apt-get update; \
 	apt-get install -y \
 		openjdk-6-jre-headless="$JAVA_DEBIAN_VERSION" \
@@ -54,4 +64,6 @@ RUN set -ex; \
 	update-alternatives --query java | grep -q 'Status: manual'
 
 # If you're reading this and have any feedback on how this image could be
-#   improved, please open an issue or a pull request so we can discuss it!
+# improved, please open an issue or a pull request so we can discuss it!
+#
+#   https://github.com/docker-library/openjdk/issues

--- a/6-jre/slim/Dockerfile
+++ b/6-jre/slim/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:stretch-curl
+FROM debian:wheezy-slim
 
 # A few reasons for installing distribution-provided OpenJDK:
 #
@@ -14,7 +14,7 @@ FROM buildpack-deps:stretch-curl
 #     really hairy.
 #
 #     For some sample build times, see Debian's buildd logs:
-#       https://buildd.debian.org/status/logs.php?pkg=openjdk-8
+#       https://buildd.debian.org/status/logs.php?pkg=openjdk-6
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzip2 \
@@ -36,15 +36,11 @@ RUN { \
 	&& chmod +x /usr/local/bin/docker-java-home
 
 # do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
-RUN ln -svT "/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)" /docker-java-home
+RUN ln -svT "/usr/lib/jvm/java-6-openjdk-$(dpkg --print-architecture)" /docker-java-home
 ENV JAVA_HOME /docker-java-home/jre
 
-ENV JAVA_VERSION 8u131
-ENV JAVA_DEBIAN_VERSION 8u131-b11-2
-
-# see https://bugs.debian.org/775775
-# and https://github.com/docker-library/java/issues/19#issuecomment-70546872
-ENV CA_CERTIFICATES_JAVA_VERSION 20170531+nmu1
+ENV JAVA_VERSION 6b38
+ENV JAVA_DEBIAN_VERSION 6b38-1.13.10-1~deb7u1
 
 RUN set -ex; \
 	\
@@ -55,8 +51,7 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y \
-		openjdk-8-jre-headless="$JAVA_DEBIAN_VERSION" \
-		ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
+		openjdk-6-jre-headless="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
@@ -67,9 +62,6 @@ RUN set -ex; \
 	update-alternatives --get-selections | awk -v home="$(readlink -f "$JAVA_HOME")" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
 # ... and verify that it actually worked for one of the alternatives we care about
 	update-alternatives --query java | grep -q 'Status: manual'
-
-# see CA_CERTIFICATES_JAVA_VERSION notes above
-RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
 
 # If you're reading this and have any feedback on how this image could be
 # improved, please open an issue or a pull request so we can discuss it!

--- a/7-jdk/Dockerfile
+++ b/7-jdk/Dockerfile
@@ -6,10 +6,15 @@
 
 FROM buildpack-deps:jessie-scm
 
-# A few problems with compiling Java from source:
+# A few reasons for installing distribution-provided OpenJDK:
+#
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.
+#
 #  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
-#       really hairy.
+#     really hairy.
+#
+#     For some sample build times, see Debian's buildd logs:
+#       https://buildd.debian.org/status/logs.php?pkg=openjdk-7
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzip2 \
@@ -39,6 +44,11 @@ ENV JAVA_DEBIAN_VERSION 7u131-2.6.9-2~deb8u1
 
 RUN set -ex; \
 	\
+# deal with slim variants not having man page directories (which causes "update-alternatives" to fail)
+	if [ ! -d /usr/share/man/man1 ]; then \
+		mkdir -p /usr/share/man/man1; \
+	fi; \
+	\
 	apt-get update; \
 	apt-get install -y \
 		openjdk-7-jdk="$JAVA_DEBIAN_VERSION" \
@@ -54,4 +64,6 @@ RUN set -ex; \
 	update-alternatives --query java | grep -q 'Status: manual'
 
 # If you're reading this and have any feedback on how this image could be
-#   improved, please open an issue or a pull request so we can discuss it!
+# improved, please open an issue or a pull request so we can discuss it!
+#
+#   https://github.com/docker-library/openjdk/issues

--- a/7-jdk/alpine/Dockerfile
+++ b/7-jdk/alpine/Dockerfile
@@ -6,10 +6,15 @@
 
 FROM alpine:3.6
 
-# A few problems with compiling Java from source:
+# A few reasons for installing distribution-provided OpenJDK:
+#
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.
+#
 #  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
-#       really hairy.
+#     really hairy.
+#
+#     For some sample build times, see Debian's buildd logs:
+#       https://buildd.debian.org/status/logs.php?pkg=openjdk-7
 
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
@@ -33,3 +38,8 @@ RUN set -x \
 	&& apk add --no-cache \
 		openjdk7="$JAVA_ALPINE_VERSION" \
 	&& [ "$JAVA_HOME" = "$(docker-java-home)" ]
+
+# If you're reading this and have any feedback on how this image could be
+# improved, please open an issue or a pull request so we can discuss it!
+#
+#   https://github.com/docker-library/openjdk/issues

--- a/7-jdk/slim/Dockerfile
+++ b/7-jdk/slim/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:stretch-curl
+FROM debian:jessie-slim
 
 # A few reasons for installing distribution-provided OpenJDK:
 #
@@ -14,7 +14,7 @@ FROM buildpack-deps:stretch-curl
 #     really hairy.
 #
 #     For some sample build times, see Debian's buildd logs:
-#       https://buildd.debian.org/status/logs.php?pkg=openjdk-8
+#       https://buildd.debian.org/status/logs.php?pkg=openjdk-7
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzip2 \
@@ -36,15 +36,11 @@ RUN { \
 	&& chmod +x /usr/local/bin/docker-java-home
 
 # do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
-RUN ln -svT "/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)" /docker-java-home
-ENV JAVA_HOME /docker-java-home/jre
+RUN ln -svT "/usr/lib/jvm/java-7-openjdk-$(dpkg --print-architecture)" /docker-java-home
+ENV JAVA_HOME /docker-java-home
 
-ENV JAVA_VERSION 8u131
-ENV JAVA_DEBIAN_VERSION 8u131-b11-2
-
-# see https://bugs.debian.org/775775
-# and https://github.com/docker-library/java/issues/19#issuecomment-70546872
-ENV CA_CERTIFICATES_JAVA_VERSION 20170531+nmu1
+ENV JAVA_VERSION 7u131
+ENV JAVA_DEBIAN_VERSION 7u131-2.6.9-2~deb8u1
 
 RUN set -ex; \
 	\
@@ -55,8 +51,7 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y \
-		openjdk-8-jre-headless="$JAVA_DEBIAN_VERSION" \
-		ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
+		openjdk-7-jdk="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
@@ -67,9 +62,6 @@ RUN set -ex; \
 	update-alternatives --get-selections | awk -v home="$(readlink -f "$JAVA_HOME")" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
 # ... and verify that it actually worked for one of the alternatives we care about
 	update-alternatives --query java | grep -q 'Status: manual'
-
-# see CA_CERTIFICATES_JAVA_VERSION notes above
-RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
 
 # If you're reading this and have any feedback on how this image could be
 # improved, please open an issue or a pull request so we can discuss it!

--- a/7-jre/Dockerfile
+++ b/7-jre/Dockerfile
@@ -6,10 +6,15 @@
 
 FROM buildpack-deps:jessie-curl
 
-# A few problems with compiling Java from source:
+# A few reasons for installing distribution-provided OpenJDK:
+#
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.
+#
 #  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
-#       really hairy.
+#     really hairy.
+#
+#     For some sample build times, see Debian's buildd logs:
+#       https://buildd.debian.org/status/logs.php?pkg=openjdk-7
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzip2 \
@@ -39,6 +44,11 @@ ENV JAVA_DEBIAN_VERSION 7u131-2.6.9-2~deb8u1
 
 RUN set -ex; \
 	\
+# deal with slim variants not having man page directories (which causes "update-alternatives" to fail)
+	if [ ! -d /usr/share/man/man1 ]; then \
+		mkdir -p /usr/share/man/man1; \
+	fi; \
+	\
 	apt-get update; \
 	apt-get install -y \
 		openjdk-7-jre-headless="$JAVA_DEBIAN_VERSION" \
@@ -54,4 +64,6 @@ RUN set -ex; \
 	update-alternatives --query java | grep -q 'Status: manual'
 
 # If you're reading this and have any feedback on how this image could be
-#   improved, please open an issue or a pull request so we can discuss it!
+# improved, please open an issue or a pull request so we can discuss it!
+#
+#   https://github.com/docker-library/openjdk/issues

--- a/7-jre/alpine/Dockerfile
+++ b/7-jre/alpine/Dockerfile
@@ -6,10 +6,15 @@
 
 FROM alpine:3.6
 
-# A few problems with compiling Java from source:
+# A few reasons for installing distribution-provided OpenJDK:
+#
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.
+#
 #  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
-#       really hairy.
+#     really hairy.
+#
+#     For some sample build times, see Debian's buildd logs:
+#       https://buildd.debian.org/status/logs.php?pkg=openjdk-7
 
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
@@ -33,3 +38,8 @@ RUN set -x \
 	&& apk add --no-cache \
 		openjdk7-jre="$JAVA_ALPINE_VERSION" \
 	&& [ "$JAVA_HOME" = "$(docker-java-home)" ]
+
+# If you're reading this and have any feedback on how this image could be
+# improved, please open an issue or a pull request so we can discuss it!
+#
+#   https://github.com/docker-library/openjdk/issues

--- a/7-jre/slim/Dockerfile
+++ b/7-jre/slim/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:stretch-curl
+FROM debian:jessie-slim
 
 # A few reasons for installing distribution-provided OpenJDK:
 #
@@ -14,7 +14,7 @@ FROM buildpack-deps:stretch-curl
 #     really hairy.
 #
 #     For some sample build times, see Debian's buildd logs:
-#       https://buildd.debian.org/status/logs.php?pkg=openjdk-8
+#       https://buildd.debian.org/status/logs.php?pkg=openjdk-7
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzip2 \
@@ -36,15 +36,11 @@ RUN { \
 	&& chmod +x /usr/local/bin/docker-java-home
 
 # do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
-RUN ln -svT "/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)" /docker-java-home
+RUN ln -svT "/usr/lib/jvm/java-7-openjdk-$(dpkg --print-architecture)" /docker-java-home
 ENV JAVA_HOME /docker-java-home/jre
 
-ENV JAVA_VERSION 8u131
-ENV JAVA_DEBIAN_VERSION 8u131-b11-2
-
-# see https://bugs.debian.org/775775
-# and https://github.com/docker-library/java/issues/19#issuecomment-70546872
-ENV CA_CERTIFICATES_JAVA_VERSION 20170531+nmu1
+ENV JAVA_VERSION 7u131
+ENV JAVA_DEBIAN_VERSION 7u131-2.6.9-2~deb8u1
 
 RUN set -ex; \
 	\
@@ -55,8 +51,7 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y \
-		openjdk-8-jre-headless="$JAVA_DEBIAN_VERSION" \
-		ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
+		openjdk-7-jre-headless="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
@@ -67,9 +62,6 @@ RUN set -ex; \
 	update-alternatives --get-selections | awk -v home="$(readlink -f "$JAVA_HOME")" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
 # ... and verify that it actually worked for one of the alternatives we care about
 	update-alternatives --query java | grep -q 'Status: manual'
-
-# see CA_CERTIFICATES_JAVA_VERSION notes above
-RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
 
 # If you're reading this and have any feedback on how this image could be
 # improved, please open an issue or a pull request so we can discuss it!

--- a/8-jdk/Dockerfile
+++ b/8-jdk/Dockerfile
@@ -6,10 +6,15 @@
 
 FROM buildpack-deps:stretch-scm
 
-# A few problems with compiling Java from source:
+# A few reasons for installing distribution-provided OpenJDK:
+#
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.
+#
 #  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
-#       really hairy.
+#     really hairy.
+#
+#     For some sample build times, see Debian's buildd logs:
+#       https://buildd.debian.org/status/logs.php?pkg=openjdk-8
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzip2 \
@@ -43,6 +48,11 @@ ENV CA_CERTIFICATES_JAVA_VERSION 20170531+nmu1
 
 RUN set -ex; \
 	\
+# deal with slim variants not having man page directories (which causes "update-alternatives" to fail)
+	if [ ! -d /usr/share/man/man1 ]; then \
+		mkdir -p /usr/share/man/man1; \
+	fi; \
+	\
 	apt-get update; \
 	apt-get install -y \
 		openjdk-8-jdk="$JAVA_DEBIAN_VERSION" \
@@ -62,4 +72,6 @@ RUN set -ex; \
 RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
 
 # If you're reading this and have any feedback on how this image could be
-#   improved, please open an issue or a pull request so we can discuss it!
+# improved, please open an issue or a pull request so we can discuss it!
+#
+#   https://github.com/docker-library/openjdk/issues

--- a/8-jdk/alpine/Dockerfile
+++ b/8-jdk/alpine/Dockerfile
@@ -6,10 +6,15 @@
 
 FROM alpine:3.6
 
-# A few problems with compiling Java from source:
+# A few reasons for installing distribution-provided OpenJDK:
+#
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.
+#
 #  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
-#       really hairy.
+#     really hairy.
+#
+#     For some sample build times, see Debian's buildd logs:
+#       https://buildd.debian.org/status/logs.php?pkg=openjdk-8
 
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
@@ -33,3 +38,8 @@ RUN set -x \
 	&& apk add --no-cache \
 		openjdk8="$JAVA_ALPINE_VERSION" \
 	&& [ "$JAVA_HOME" = "$(docker-java-home)" ]
+
+# If you're reading this and have any feedback on how this image could be
+# improved, please open an issue or a pull request so we can discuss it!
+#
+#   https://github.com/docker-library/openjdk/issues

--- a/8-jdk/slim/Dockerfile
+++ b/8-jdk/slim/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:stretch-curl
+FROM debian:stretch-slim
 
 # A few reasons for installing distribution-provided OpenJDK:
 #
@@ -37,7 +37,7 @@ RUN { \
 
 # do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
 RUN ln -svT "/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)" /docker-java-home
-ENV JAVA_HOME /docker-java-home/jre
+ENV JAVA_HOME /docker-java-home
 
 ENV JAVA_VERSION 8u131
 ENV JAVA_DEBIAN_VERSION 8u131-b11-2
@@ -55,7 +55,7 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y \
-		openjdk-8-jre-headless="$JAVA_DEBIAN_VERSION" \
+		openjdk-8-jdk-headless="$JAVA_DEBIAN_VERSION" \
 		ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \

--- a/8-jre/alpine/Dockerfile
+++ b/8-jre/alpine/Dockerfile
@@ -6,10 +6,15 @@
 
 FROM alpine:3.6
 
-# A few problems with compiling Java from source:
+# A few reasons for installing distribution-provided OpenJDK:
+#
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.
+#
 #  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
-#       really hairy.
+#     really hairy.
+#
+#     For some sample build times, see Debian's buildd logs:
+#       https://buildd.debian.org/status/logs.php?pkg=openjdk-8
 
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
@@ -33,3 +38,8 @@ RUN set -x \
 	&& apk add --no-cache \
 		openjdk8-jre="$JAVA_ALPINE_VERSION" \
 	&& [ "$JAVA_HOME" = "$(docker-java-home)" ]
+
+# If you're reading this and have any feedback on how this image could be
+# improved, please open an issue or a pull request so we can discuss it!
+#
+#   https://github.com/docker-library/openjdk/issues

--- a/8-jre/slim/Dockerfile
+++ b/8-jre/slim/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:stretch-curl
+FROM debian:stretch-slim
 
 # A few reasons for installing distribution-provided OpenJDK:
 #

--- a/9-jdk/Dockerfile
+++ b/9-jdk/Dockerfile
@@ -6,10 +6,15 @@
 
 FROM buildpack-deps:sid-scm
 
-# A few problems with compiling Java from source:
+# A few reasons for installing distribution-provided OpenJDK:
+#
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.
+#
 #  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
-#       really hairy.
+#     really hairy.
+#
+#     For some sample build times, see Debian's buildd logs:
+#       https://buildd.debian.org/status/logs.php?pkg=openjdk-9
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzip2 \
@@ -41,6 +46,11 @@ ENV JAVA_DEBIAN_VERSION 9~b177-3
 
 RUN set -ex; \
 	\
+# deal with slim variants not having man page directories (which causes "update-alternatives" to fail)
+	if [ ! -d /usr/share/man/man1 ]; then \
+		mkdir -p /usr/share/man/man1; \
+	fi; \
+	\
 	apt-get update; \
 	apt-get install -y \
 		openjdk-9-jdk-headless="$JAVA_DEBIAN_VERSION" \
@@ -56,4 +66,6 @@ RUN set -ex; \
 	update-alternatives --query java | grep -q 'Status: manual'
 
 # If you're reading this and have any feedback on how this image could be
-#   improved, please open an issue or a pull request so we can discuss it!
+# improved, please open an issue or a pull request so we can discuss it!
+#
+#   https://github.com/docker-library/openjdk/issues

--- a/9-jdk/slim/Dockerfile
+++ b/9-jdk/slim/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:stretch-curl
+FROM debian:sid-slim
 
 # A few reasons for installing distribution-provided OpenJDK:
 #
@@ -14,13 +14,15 @@ FROM buildpack-deps:stretch-curl
 #     really hairy.
 #
 #     For some sample build times, see Debian's buildd logs:
-#       https://buildd.debian.org/status/logs.php?pkg=openjdk-8
+#       https://buildd.debian.org/status/logs.php?pkg=openjdk-9
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzip2 \
 		unzip \
 		xz-utils \
 	&& rm -rf /var/lib/apt/lists/*
+
+RUN echo 'deb http://deb.debian.org/debian experimental main' > /etc/apt/sources.list.d/experimental.list
 
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
@@ -36,15 +38,11 @@ RUN { \
 	&& chmod +x /usr/local/bin/docker-java-home
 
 # do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
-RUN ln -svT "/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)" /docker-java-home
-ENV JAVA_HOME /docker-java-home/jre
+RUN ln -svT "/usr/lib/jvm/java-9-openjdk-$(dpkg --print-architecture)" /docker-java-home
+ENV JAVA_HOME /docker-java-home
 
-ENV JAVA_VERSION 8u131
-ENV JAVA_DEBIAN_VERSION 8u131-b11-2
-
-# see https://bugs.debian.org/775775
-# and https://github.com/docker-library/java/issues/19#issuecomment-70546872
-ENV CA_CERTIFICATES_JAVA_VERSION 20170531+nmu1
+ENV JAVA_VERSION 9-b177
+ENV JAVA_DEBIAN_VERSION 9~b177-3
 
 RUN set -ex; \
 	\
@@ -55,8 +53,7 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y \
-		openjdk-8-jre-headless="$JAVA_DEBIAN_VERSION" \
-		ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
+		openjdk-9-jdk-headless="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
@@ -67,9 +64,6 @@ RUN set -ex; \
 	update-alternatives --get-selections | awk -v home="$(readlink -f "$JAVA_HOME")" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
 # ... and verify that it actually worked for one of the alternatives we care about
 	update-alternatives --query java | grep -q 'Status: manual'
-
-# see CA_CERTIFICATES_JAVA_VERSION notes above
-RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
 
 # If you're reading this and have any feedback on how this image could be
 # improved, please open an issue or a pull request so we can discuss it!

--- a/9-jre/Dockerfile
+++ b/9-jre/Dockerfile
@@ -6,10 +6,15 @@
 
 FROM buildpack-deps:sid-curl
 
-# A few problems with compiling Java from source:
+# A few reasons for installing distribution-provided OpenJDK:
+#
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.
+#
 #  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
-#       really hairy.
+#     really hairy.
+#
+#     For some sample build times, see Debian's buildd logs:
+#       https://buildd.debian.org/status/logs.php?pkg=openjdk-9
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzip2 \
@@ -41,6 +46,11 @@ ENV JAVA_DEBIAN_VERSION 9~b177-3
 
 RUN set -ex; \
 	\
+# deal with slim variants not having man page directories (which causes "update-alternatives" to fail)
+	if [ ! -d /usr/share/man/man1 ]; then \
+		mkdir -p /usr/share/man/man1; \
+	fi; \
+	\
 	apt-get update; \
 	apt-get install -y \
 		openjdk-9-jre-headless="$JAVA_DEBIAN_VERSION" \
@@ -56,4 +66,6 @@ RUN set -ex; \
 	update-alternatives --query java | grep -q 'Status: manual'
 
 # If you're reading this and have any feedback on how this image could be
-#   improved, please open an issue or a pull request so we can discuss it!
+# improved, please open an issue or a pull request so we can discuss it!
+#
+#   https://github.com/docker-library/openjdk/issues

--- a/9-jre/slim/Dockerfile
+++ b/9-jre/slim/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:stretch-curl
+FROM debian:sid-slim
 
 # A few reasons for installing distribution-provided OpenJDK:
 #
@@ -14,13 +14,15 @@ FROM buildpack-deps:stretch-curl
 #     really hairy.
 #
 #     For some sample build times, see Debian's buildd logs:
-#       https://buildd.debian.org/status/logs.php?pkg=openjdk-8
+#       https://buildd.debian.org/status/logs.php?pkg=openjdk-9
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzip2 \
 		unzip \
 		xz-utils \
 	&& rm -rf /var/lib/apt/lists/*
+
+RUN echo 'deb http://deb.debian.org/debian experimental main' > /etc/apt/sources.list.d/experimental.list
 
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
@@ -36,15 +38,11 @@ RUN { \
 	&& chmod +x /usr/local/bin/docker-java-home
 
 # do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
-RUN ln -svT "/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)" /docker-java-home
-ENV JAVA_HOME /docker-java-home/jre
+RUN ln -svT "/usr/lib/jvm/java-9-openjdk-$(dpkg --print-architecture)" /docker-java-home
+ENV JAVA_HOME /docker-java-home
 
-ENV JAVA_VERSION 8u131
-ENV JAVA_DEBIAN_VERSION 8u131-b11-2
-
-# see https://bugs.debian.org/775775
-# and https://github.com/docker-library/java/issues/19#issuecomment-70546872
-ENV CA_CERTIFICATES_JAVA_VERSION 20170531+nmu1
+ENV JAVA_VERSION 9-b177
+ENV JAVA_DEBIAN_VERSION 9~b177-3
 
 RUN set -ex; \
 	\
@@ -55,8 +53,7 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y \
-		openjdk-8-jre-headless="$JAVA_DEBIAN_VERSION" \
-		ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
+		openjdk-9-jre-headless="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
@@ -67,9 +64,6 @@ RUN set -ex; \
 	update-alternatives --get-selections | awk -v home="$(readlink -f "$JAVA_HOME")" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
 # ... and verify that it actually worked for one of the alternatives we care about
 	update-alternatives --query java | grep -q 'Status: manual'
-
-# see CA_CERTIFICATES_JAVA_VERSION notes above
-RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
 
 # If you're reading this and have any feedback on how this image could be
 # improved, please open an issue or a pull request so we can discuss it!

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -130,7 +130,7 @@ for version in "${versions[@]}"; do
 	EOE
 
 	for v in \
-		alpine \
+		slim alpine \
 		windows/windowsservercore windows/nanoserver \
 	; do
 		dir="$version/$v"


### PR DESCRIPTION
Closes #131

cc @bjornbak :+1:

I think we should consider swapping the non-`slim` variants to not use `-headless` as well, but IMO that should happen as a separate discussion for this one (I only bring it up because having this is a precursor to being able to consider something like that, ala #130). :smile: