### PR TITLE
Add "jshell" as the default command for Java 9+ JDK images

### DIFF
--- a/9-jdk/Dockerfile
+++ b/9-jdk/Dockerfile
@@ -65,6 +65,10 @@ RUN set -ex; \
 # ... and verify that it actually worked for one of the alternatives we care about
 	update-alternatives --query java | grep -q 'Status: manual'
 
+# https://docs.oracle.com/javase/9/tools/jshell.htm
+# https://en.wikipedia.org/wiki/JShell
+CMD ["jshell"]
+
 # If you're reading this and have any feedback on how this image could be
 # improved, please open an issue or a pull request so we can discuss it!
 #

--- a/9-jdk/slim/Dockerfile
+++ b/9-jdk/slim/Dockerfile
@@ -65,6 +65,10 @@ RUN set -ex; \
 # ... and verify that it actually worked for one of the alternatives we care about
 	update-alternatives --query java | grep -q 'Status: manual'
 
+# https://docs.oracle.com/javase/9/tools/jshell.htm
+# https://en.wikipedia.org/wiki/JShell
+CMD ["jshell"]
+
 # If you're reading this and have any feedback on how this image could be
 # improved, please open an issue or a pull request so we can discuss it!
 #

--- a/9-jdk/windows/nanoserver/Dockerfile
+++ b/9-jdk/windows/nanoserver/Dockerfile
@@ -41,3 +41,7 @@ RUN $url = ('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/{1}' -
 	Remove-Item ojdkbuild.zip -Force; \
 	\
 	Write-Host 'Complete.';
+
+# https://docs.oracle.com/javase/9/tools/jshell.htm
+# https://en.wikipedia.org/wiki/JShell
+CMD ["jshell"]

--- a/9-jdk/windows/windowsservercore/Dockerfile
+++ b/9-jdk/windows/windowsservercore/Dockerfile
@@ -41,3 +41,7 @@ RUN $url = ('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/{1}' -
 	Remove-Item ojdkbuild.zip -Force; \
 	\
 	Write-Host 'Complete.';
+
+# https://docs.oracle.com/javase/9/tools/jshell.htm
+# https://en.wikipedia.org/wiki/JShell
+CMD ["jshell"]

--- a/update.sh
+++ b/update.sh
@@ -281,6 +281,15 @@ EOD
 		EOD
 	fi
 
+	if [ "$javaType" = 'jdk' ] && [ "$javaVersion" -ge 9 ]; then
+		cat >> "$version/Dockerfile" <<-'EOD'
+
+			# https://docs.oracle.com/javase/9/tools/jshell.htm
+			# https://en.wikipedia.org/wiki/JShell
+			CMD ["jshell"]
+		EOD
+	fi
+
 	template-contribute-footer >> "$version/Dockerfile"
 
 	if [ -d "$version/alpine" ]; then


### PR DESCRIPTION
See https://en.wikipedia.org/wiki/JShell and https://docs.oracle.com/javase/9/tools/jshell.htm for more information -- this is a REPL that's included with Java 9+. :metal:

Closes #139