### PR TITLE
Swap regular versions to non-headless jre/jdk

### DIFF
--- a/6-jre/Dockerfile
+++ b/6-jre/Dockerfile
@@ -51,7 +51,7 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y \
-		openjdk-6-jre-headless="$JAVA_DEBIAN_VERSION" \
+		openjdk-6-jre="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/7-jre/Dockerfile
+++ b/7-jre/Dockerfile
@@ -51,7 +51,7 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y \
-		openjdk-7-jre-headless="$JAVA_DEBIAN_VERSION" \
+		openjdk-7-jre="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/8-jre/Dockerfile
+++ b/8-jre/Dockerfile
@@ -55,7 +55,7 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y \
-		openjdk-8-jre-headless="$JAVA_DEBIAN_VERSION" \
+		openjdk-8-jre="$JAVA_DEBIAN_VERSION" \
 		ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \

--- a/9-jdk/Dockerfile
+++ b/9-jdk/Dockerfile
@@ -51,7 +51,7 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y \
-		openjdk-9-jdk-headless="$JAVA_DEBIAN_VERSION" \
+		openjdk-9-jdk="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/9-jre/Dockerfile
+++ b/9-jre/Dockerfile
@@ -51,7 +51,7 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y \
-		openjdk-9-jre-headless="$JAVA_DEBIAN_VERSION" \
+		openjdk-9-jre="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/update.sh
+++ b/update.sh
@@ -176,10 +176,6 @@ for version in "${versions[@]}"; do
 	fi
 
 	debianPackage="openjdk-$javaVersion-$javaType"
-	if [ "$javaType" = 'jre' -o "$javaVersion" -ge 9 ]; then
-		# "openjdk-9" in Debian introduced an "openjdk-9-jdk-headless" package \o/
-		debianPackage+='-headless'
-	fi
 	debSuite="${addSuite:-$suite}"
 	debian-latest-version "$debianPackage" "$debSuite" > /dev/null # prime the cache
 	debianVersion="$(debian-latest-version "$debianPackage" "$debSuite")"
@@ -356,7 +352,7 @@ EOD
 		#   - swap "openjdk-N-(jre|jdk) for the -headless versions, where available (openjdk-8+ only for JDK variants)
 		sed -r \
 			-e 's!^FROM buildpack-deps:([^-]+)(-.+)?!FROM debian:\1-slim!' \
-			-e 's!(openjdk-(\d+-jre|([89]\d*|\d\d+)-jdk))=!\1-headless=!g' \
+			-e 's!(openjdk-([0-9]+-jre|([89]\d*|\d\d+)-jdk))=!\1-headless=!g' \
 			"$version/Dockerfile" > "$version/slim/Dockerfile"
 
 		travisEnv='\n  - VERSION='"$version"' VARIANT=slim'"$travisEnv"


### PR DESCRIPTION
Fixes #129. (test for official-images incoming, and some docs to update the `slim`/non-slim description)