### PR TITLE
Use  --no-install-recommends with apt-get install

### DIFF
--- a/10-jdk/Dockerfile
+++ b/10-jdk/Dockerfile
@@ -54,7 +54,7 @@ RUN set -ex; \
 	ln -svT /docker-java-home/bin/java /usr/local/bin/java; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	apt-get install -y --no-install-recommends \
 		openjdk-10-jdk="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \

--- a/10-jdk/slim/Dockerfile
+++ b/10-jdk/slim/Dockerfile
@@ -54,7 +54,7 @@ RUN set -ex; \
 	ln -svT /docker-java-home/bin/java /usr/local/bin/java; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	apt-get install -y --no-install-recommends \
 		openjdk-10-jdk="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \

--- a/10-jre/Dockerfile
+++ b/10-jre/Dockerfile
@@ -54,7 +54,7 @@ RUN set -ex; \
 	ln -svT /docker-java-home/bin/java /usr/local/bin/java; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	apt-get install -y --no-install-recommends \
 		openjdk-10-jre="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \

--- a/10-jre/slim/Dockerfile
+++ b/10-jre/slim/Dockerfile
@@ -54,7 +54,7 @@ RUN set -ex; \
 	ln -svT /docker-java-home/bin/java /usr/local/bin/java; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	apt-get install -y --no-install-recommends \
 		openjdk-10-jre-headless="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \

--- a/11-jdk/Dockerfile
+++ b/11-jdk/Dockerfile
@@ -50,7 +50,7 @@ RUN set -ex; \
 	fi; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	apt-get install -y --no-install-recommends \
 		openjdk-11-jdk="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \

--- a/11-jdk/slim/Dockerfile
+++ b/11-jdk/slim/Dockerfile
@@ -50,7 +50,7 @@ RUN set -ex; \
 	fi; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	apt-get install -y --no-install-recommends \
 		openjdk-11-jdk="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \

--- a/11-jre/Dockerfile
+++ b/11-jre/Dockerfile
@@ -50,7 +50,7 @@ RUN set -ex; \
 	fi; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	apt-get install -y --no-install-recommends \
 		openjdk-11-jre="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \

--- a/11-jre/slim/Dockerfile
+++ b/11-jre/slim/Dockerfile
@@ -50,7 +50,7 @@ RUN set -ex; \
 	fi; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	apt-get install -y --no-install-recommends \
 		openjdk-11-jre-headless="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \

--- a/7-jdk/Dockerfile
+++ b/7-jdk/Dockerfile
@@ -50,7 +50,7 @@ RUN set -ex; \
 	fi; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	apt-get install -y --no-install-recommends \
 		openjdk-7-jdk="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \

--- a/7-jdk/slim/Dockerfile
+++ b/7-jdk/slim/Dockerfile
@@ -50,7 +50,7 @@ RUN set -ex; \
 	fi; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	apt-get install -y --no-install-recommends \
 		openjdk-7-jdk="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \

--- a/7-jre/Dockerfile
+++ b/7-jre/Dockerfile
@@ -50,7 +50,7 @@ RUN set -ex; \
 	fi; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	apt-get install -y --no-install-recommends \
 		openjdk-7-jre="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \

--- a/7-jre/slim/Dockerfile
+++ b/7-jre/slim/Dockerfile
@@ -50,7 +50,7 @@ RUN set -ex; \
 	fi; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	apt-get install -y --no-install-recommends \
 		openjdk-7-jre-headless="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \

--- a/8-jdk/Dockerfile
+++ b/8-jdk/Dockerfile
@@ -54,7 +54,7 @@ RUN set -ex; \
 	fi; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	apt-get install -y --no-install-recommends \
 		openjdk-8-jdk="$JAVA_DEBIAN_VERSION" \
 		ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
 	; \

--- a/8-jdk/slim/Dockerfile
+++ b/8-jdk/slim/Dockerfile
@@ -54,7 +54,7 @@ RUN set -ex; \
 	fi; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	apt-get install -y --no-install-recommends \
 		openjdk-8-jdk-headless="$JAVA_DEBIAN_VERSION" \
 		ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
 	; \

--- a/8-jre/Dockerfile
+++ b/8-jre/Dockerfile
@@ -54,7 +54,7 @@ RUN set -ex; \
 	fi; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	apt-get install -y --no-install-recommends \
 		openjdk-8-jre="$JAVA_DEBIAN_VERSION" \
 		ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
 	; \

--- a/8-jre/slim/Dockerfile
+++ b/8-jre/slim/Dockerfile
@@ -54,7 +54,7 @@ RUN set -ex; \
 	fi; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	apt-get install -y --no-install-recommends \
 		openjdk-8-jre-headless="$JAVA_DEBIAN_VERSION" \
 		ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
 	; \

--- a/9-jdk/Dockerfile
+++ b/9-jdk/Dockerfile
@@ -50,7 +50,7 @@ RUN set -ex; \
 	fi; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	apt-get install -y --no-install-recommends \
 		openjdk-9-jdk="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \

--- a/9-jdk/slim/Dockerfile
+++ b/9-jdk/slim/Dockerfile
@@ -50,7 +50,7 @@ RUN set -ex; \
 	fi; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	apt-get install -y --no-install-recommends \
 		openjdk-9-jdk-headless="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \

--- a/9-jre/Dockerfile
+++ b/9-jre/Dockerfile
@@ -50,7 +50,7 @@ RUN set -ex; \
 	fi; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	apt-get install -y --no-install-recommends \
 		openjdk-9-jre="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \

--- a/9-jre/slim/Dockerfile
+++ b/9-jre/slim/Dockerfile
@@ -50,7 +50,7 @@ RUN set -ex; \
 	fi; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	apt-get install -y --no-install-recommends \
 		openjdk-9-jre-headless="$JAVA_DEBIAN_VERSION" \
 	; \
 	rm -rf /var/lib/apt/lists/*; \

--- a/update.sh
+++ b/update.sh
@@ -271,7 +271,7 @@ RUN set -ex; \\
 	fi; \\
 	$sillyCaSymlink
 	apt-get update; \\
-	apt-get install -y \\
+	apt-get install -y --no-install-recommends \\
 		$debianPackage="\$JAVA_DEBIAN_VERSION" \\
 EOD
 	if [ "$needCaHack" ]; then


### PR DESCRIPTION
With that `libxt-dev` is no longer installed.