### PR TITLE
added fontconfig and ttf-dejavu as packages

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -359,6 +359,8 @@ EOD
 RUN set -x \\
 	&& apk add --no-cache \\
 		${alpinePackage}="\$JAVA_ALPINE_VERSION" \\
+		fontconfig \\
+		ttf-dejavu \\
 	&& [ "\$JAVA_HOME" = "\$(docker-java-home)" ]
 EOD
 


### PR DESCRIPTION
This closes #73.

This should only add the `fontconfig` and `ttf-dejavu` packages to the jre-alpine branches, since the others aren't broken (as far as I know).

This seems like the right upstream place to add these packages, since it seems like these openjdk-alpine containers are used as the basis for java-based web applications--for example, I came here from [tomcat:jre8-alpine](https://github.com/docker-library/tomcat/blob/master/9.0/jre8-alpine/Dockerfile), which is used for the Azure App service [tomcat container](https://github.com/Azure-App-Service/tomcat), which is currently in preview.

