### PR TITLE
Use newer alpine OpenJDK package that fixes security vulnerability

### DIFF
--- a/8/jdk/alpine/Dockerfile
+++ b/8/jdk/alpine/Dockerfile
@@ -32,7 +32,7 @@ ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
 ENV PATH $PATH:/usr/lib/jvm/java-1.8-openjdk/jre/bin:/usr/lib/jvm/java-1.8-openjdk/bin
 
 ENV JAVA_VERSION 8u171
-ENV JAVA_ALPINE_VERSION 8.171.11-r0
+ENV JAVA_ALPINE_VERSION 8.171.11-r2
 
 RUN set -x \
 	&& apk add --no-cache \

--- a/8/jre/alpine/Dockerfile
+++ b/8/jre/alpine/Dockerfile
@@ -32,7 +32,7 @@ ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk/jre
 ENV PATH $PATH:/usr/lib/jvm/java-1.8-openjdk/jre/bin:/usr/lib/jvm/java-1.8-openjdk/bin
 
 ENV JAVA_VERSION 8u171
-ENV JAVA_ALPINE_VERSION 8.171.11-r0
+ENV JAVA_ALPINE_VERSION 8.171.11-r2
 
 RUN set -x \
 	&& apk add --no-cache \


### PR DESCRIPTION
Use newer alpine OpenJDK package 8.171.11-r2 that addresses CVE-2017-15088 security vulnerability