### PR TITLE
Support for https sources in /etc/apt/sources.list

### DIFF
--- a/8/jdk/Dockerfile
+++ b/8/jdk/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzip2 \
 		unzip \
 		xz-utils \
+		apt-transport-https \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Default to UTF-8 file.encoding


### PR DESCRIPTION
Context:
Currently if the openjdk:8 image is used as a base image to build another image in a secured environment that has no access to http://deb.debian.org/, /etc/apt/sources.list has to be updated with the internal (i.e used in a company) mirror used for installing debian packages and running typical commands such as ```apt-get udpate```

Problem: 
This doesn't work out of the box if the mirror is using https, for that matter the package ```apt-transport-https``` has to be installed beforehand, so you can easily update /etc/apt/sources.list with the internal mirrors, and run whatever commands you need

Not sure if the same applies for applies for the alpine and slim images, happy to hear your thoughts though.