### PR TITLE
Add Windows bits for 11 and 12 from jdk.java.net (official upstream builds!)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,6 +3,10 @@ image: Visual Studio 2017
 
 environment:
   matrix:
+    - version: 12
+      variant: windowsservercore-ltsc2016
+    - version: 11
+      variant: windowsservercore-ltsc2016
     - version: 10
       variant: windowsservercore-ltsc2016
     - version: 10

--- a/11/jdk/windows/windowsservercore-1709/Dockerfile
+++ b/11/jdk/windows/windowsservercore-1709/Dockerfile
@@ -1,0 +1,40 @@
+FROM microsoft/windowsservercore:1709
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV JAVA_HOME C:\\jdk-11
+RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+# Nano Server does not have "[Environment]::SetEnvironmentVariable()"
+	setx /M PATH $newPath
+
+# http://jdk.java.net/
+ENV JAVA_VERSION 11+28
+ENV JAVA_URL https://download.java.net/java/early_access/jdk11/28/GPL/openjdk-11+28_windows-x64_bin.zip
+ENV JAVA_SHA256 fde3b28ca31b86a889c37528f17411cd0b9651beb6fa76cac89a223417910f4b
+
+RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.zip'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
+	if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive openjdk.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  java -version'; java -version; \
+	Write-Host '  javac -version'; javac -version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item openjdk.zip -Force; \
+	\
+	Write-Host 'Complete.'
+
+# https://docs.oracle.com/javase/10/tools/jshell.htm
+# https://en.wikipedia.org/wiki/JShell
+CMD ["jshell"]

--- a/11/jdk/windows/windowsservercore-1803/Dockerfile
+++ b/11/jdk/windows/windowsservercore-1803/Dockerfile
@@ -1,0 +1,40 @@
+FROM microsoft/windowsservercore:1803
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV JAVA_HOME C:\\jdk-11
+RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+# Nano Server does not have "[Environment]::SetEnvironmentVariable()"
+	setx /M PATH $newPath
+
+# http://jdk.java.net/
+ENV JAVA_VERSION 11+28
+ENV JAVA_URL https://download.java.net/java/early_access/jdk11/28/GPL/openjdk-11+28_windows-x64_bin.zip
+ENV JAVA_SHA256 fde3b28ca31b86a889c37528f17411cd0b9651beb6fa76cac89a223417910f4b
+
+RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.zip'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
+	if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive openjdk.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  java -version'; java -version; \
+	Write-Host '  javac -version'; javac -version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item openjdk.zip -Force; \
+	\
+	Write-Host 'Complete.'
+
+# https://docs.oracle.com/javase/10/tools/jshell.htm
+# https://en.wikipedia.org/wiki/JShell
+CMD ["jshell"]

--- a/11/jdk/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/11/jdk/windows/windowsservercore-ltsc2016/Dockerfile
@@ -1,0 +1,40 @@
+FROM microsoft/windowsservercore:ltsc2016
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV JAVA_HOME C:\\jdk-11
+RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+# Nano Server does not have "[Environment]::SetEnvironmentVariable()"
+	setx /M PATH $newPath
+
+# http://jdk.java.net/
+ENV JAVA_VERSION 11+28
+ENV JAVA_URL https://download.java.net/java/early_access/jdk11/28/GPL/openjdk-11+28_windows-x64_bin.zip
+ENV JAVA_SHA256 fde3b28ca31b86a889c37528f17411cd0b9651beb6fa76cac89a223417910f4b
+
+RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.zip'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
+	if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive openjdk.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  java -version'; java -version; \
+	Write-Host '  javac -version'; javac -version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item openjdk.zip -Force; \
+	\
+	Write-Host 'Complete.'
+
+# https://docs.oracle.com/javase/10/tools/jshell.htm
+# https://en.wikipedia.org/wiki/JShell
+CMD ["jshell"]

--- a/12/jdk/windows/windowsservercore-1709/Dockerfile
+++ b/12/jdk/windows/windowsservercore-1709/Dockerfile
@@ -1,0 +1,40 @@
+FROM microsoft/windowsservercore:1709
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV JAVA_HOME C:\\jdk-12
+RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+# Nano Server does not have "[Environment]::SetEnvironmentVariable()"
+	setx /M PATH $newPath
+
+# http://jdk.java.net/
+ENV JAVA_VERSION 12-ea+9
+ENV JAVA_URL https://download.java.net/java/early_access/jdk12/9/GPL/openjdk-12-ea+9_windows-x64_bin.zip
+ENV JAVA_SHA256 49eb49f808d2beff6c977f2f60aa75f17c8adbb3280bea482816aa6a083b0952
+
+RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.zip'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
+	if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive openjdk.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  java -version'; java -version; \
+	Write-Host '  javac -version'; javac -version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item openjdk.zip -Force; \
+	\
+	Write-Host 'Complete.'
+
+# https://docs.oracle.com/javase/10/tools/jshell.htm
+# https://en.wikipedia.org/wiki/JShell
+CMD ["jshell"]

--- a/12/jdk/windows/windowsservercore-1803/Dockerfile
+++ b/12/jdk/windows/windowsservercore-1803/Dockerfile
@@ -1,0 +1,40 @@
+FROM microsoft/windowsservercore:1803
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV JAVA_HOME C:\\jdk-12
+RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+# Nano Server does not have "[Environment]::SetEnvironmentVariable()"
+	setx /M PATH $newPath
+
+# http://jdk.java.net/
+ENV JAVA_VERSION 12-ea+9
+ENV JAVA_URL https://download.java.net/java/early_access/jdk12/9/GPL/openjdk-12-ea+9_windows-x64_bin.zip
+ENV JAVA_SHA256 49eb49f808d2beff6c977f2f60aa75f17c8adbb3280bea482816aa6a083b0952
+
+RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.zip'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
+	if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive openjdk.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  java -version'; java -version; \
+	Write-Host '  javac -version'; javac -version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item openjdk.zip -Force; \
+	\
+	Write-Host 'Complete.'
+
+# https://docs.oracle.com/javase/10/tools/jshell.htm
+# https://en.wikipedia.org/wiki/JShell
+CMD ["jshell"]

--- a/12/jdk/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/12/jdk/windows/windowsservercore-ltsc2016/Dockerfile
@@ -1,0 +1,40 @@
+FROM microsoft/windowsservercore:ltsc2016
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV JAVA_HOME C:\\jdk-12
+RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+# Nano Server does not have "[Environment]::SetEnvironmentVariable()"
+	setx /M PATH $newPath
+
+# http://jdk.java.net/
+ENV JAVA_VERSION 12-ea+9
+ENV JAVA_URL https://download.java.net/java/early_access/jdk12/9/GPL/openjdk-12-ea+9_windows-x64_bin.zip
+ENV JAVA_SHA256 49eb49f808d2beff6c977f2f60aa75f17c8adbb3280bea482816aa6a083b0952
+
+RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.zip'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
+	if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive openjdk.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  java -version'; java -version; \
+	Write-Host '  javac -version'; javac -version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item openjdk.zip -Force; \
+	\
+	Write-Host 'Complete.'
+
+# https://docs.oracle.com/javase/10/tools/jshell.htm
+# https://en.wikipedia.org/wiki/JShell
+CMD ["jshell"]

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -125,8 +125,8 @@ for javaVersion in "${versions[@]}"; do
 	for javaType in jdk jre; do
 		for v in \
 			'' slim alpine \
-			windows/windowsservercore-{ltsc2016,1709} \
-			windows/nanoserver-{sac2016,1709} \
+			windows/windowsservercore-{ltsc2016,1709,1803} \
+			windows/nanoserver-{sac2016,1709,1803} \
 		; do
 			dir="$javaVersion/$javaType${v:+/$v}"
 			[ -n "$v" ] && variant="$(basename "$v")" || variant=

--- a/update.sh
+++ b/update.sh
@@ -169,38 +169,39 @@ for javaVersion in "${versions[@]}"; do
 	for javaType in jdk jre; do
 		dir="$javaVersion/$javaType"
 
-		suite="${suites[$javaVersion]}"
-		addSuite="${addSuites[$javaVersion]:-}"
-		buildpackDepsVariant="${buildpackDepsVariants[$javaType]}"
+		suite="${suites[$javaVersion]:-}"
+		if [ -n "$suite" ]; then
+			addSuite="${addSuites[$javaVersion]:-}"
+			buildpackDepsVariant="${buildpackDepsVariants[$javaType]}"
 
-		needCaHack=
-		if [ "$javaVersion" -ge 8 -a "$suite" != 'sid' ]; then
-			# "20140324" is broken (jessie), but "20160321" is fixed (sid)
-			needCaHack=1
-		fi
+			needCaHack=
+			if [ "$javaVersion" -ge 8 -a "$suite" != 'sid' ]; then
+				# "20140324" is broken (jessie), but "20160321" is fixed (sid)
+				needCaHack=1
+			fi
 
-		debianPackage="openjdk-$javaVersion-$javaType"
-		debSuite="${addSuite:-$suite}"
-		debian-latest-version "$debianPackage" "$debSuite" > /dev/null # prime the cache
-		debianVersion="$(debian-latest-version "$debianPackage" "$debSuite")"
-		fullVersion="${debianVersion%%-*}"
-		fullVersion="${fullVersion#*:}"
+			debianPackage="openjdk-$javaVersion-$javaType"
+			debSuite="${addSuite:-$suite}"
+			debian-latest-version "$debianPackage" "$debSuite" > /dev/null # prime the cache
+			debianVersion="$(debian-latest-version "$debianPackage" "$debSuite")"
+			fullVersion="${debianVersion%%-*}"
+			fullVersion="${fullVersion#*:}"
 
-		tilde='~'
-		case "$javaVersion" in
-			10|11)
-				# update Debian's "10~39" to "10-ea+39" (matching http://jdk.java.net/10/)
-				# update Debian's "11~8" to "11-ea+8" (matching http://jdk.java.net/11/)
-				fullVersion="${fullVersion//$javaVersion$tilde/$javaVersion-ea+}"
-				;;
-		esac
-		fullVersion="${fullVersion//$tilde/-}"
+			tilde='~'
+			case "$javaVersion" in
+				10 | 11)
+					# update Debian's "10~39" to "10-ea+39" (matching http://jdk.java.net/10/)
+					# update Debian's "11~8" to "11-ea+8" (matching http://jdk.java.net/11/)
+					fullVersion="${fullVersion//$javaVersion$tilde/$javaVersion-ea+}"
+					;;
+			esac
+			fullVersion="${fullVersion//$tilde/-}"
 
-		echo "$javaVersion-$javaType: $fullVersion (debian $debianVersion)"
+			echo "$javaVersion-$javaType: $fullVersion (debian $debianVersion)"
 
-		template-generated-warning "buildpack-deps:$suite-$buildpackDepsVariant" "$javaVersion" > "$dir/Dockerfile"
+			template-generated-warning "buildpack-deps:$suite-$buildpackDepsVariant" "$javaVersion" > "$dir/Dockerfile"
 
-		cat >> "$dir/Dockerfile" <<'EOD'
+			cat >> "$dir/Dockerfile" <<'EOD'
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzip2 \
@@ -209,57 +210,57 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 EOD
 
-		if [ "$addSuite" ]; then
+			if [ "$addSuite" ]; then
+				cat >> "$dir/Dockerfile" <<-EOD
+
+					RUN echo 'deb http://deb.debian.org/debian $addSuite main' > /etc/apt/sources.list.d/$addSuite.list
+				EOD
+			fi
+
 			cat >> "$dir/Dockerfile" <<-EOD
 
-				RUN echo 'deb http://deb.debian.org/debian $addSuite main' > /etc/apt/sources.list.d/$addSuite.list
+				# Default to UTF-8 file.encoding
+				ENV LANG C.UTF-8
 			EOD
-		fi
 
-		cat >> "$dir/Dockerfile" <<-EOD
+			template-java-home-script >> "$dir/Dockerfile"
 
-			# Default to UTF-8 file.encoding
-			ENV LANG C.UTF-8
-		EOD
-
-		template-java-home-script >> "$dir/Dockerfile"
-
-		jreSuffix=
-		if [ "$javaType" = 'jre' -a "$javaVersion" -lt 9 ]; then
-			# woot, this hackery stopped in OpenJDK 9+!
-			jreSuffix='/jre'
-		fi
-		cat >> "$dir/Dockerfile" <<-EOD
-
-			# do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
-			RUN ln -svT "/usr/lib/jvm/java-$javaVersion-openjdk-\$(dpkg --print-architecture)" /docker-java-home
-			ENV JAVA_HOME /docker-java-home$jreSuffix
-
-			ENV JAVA_VERSION $fullVersion
-			ENV JAVA_DEBIAN_VERSION $debianVersion
-		EOD
-
-		if [ "$needCaHack" ]; then
-			debian-latest-version 'ca-certificates-java' "$debSuite" > /dev/null # prime the cache
-			caCertHackVersion="$(debian-latest-version 'ca-certificates-java' "$debSuite")"
+			jreSuffix=
+			if [ "$javaType" = 'jre' -a "$javaVersion" -lt 9 ]; then
+				# woot, this hackery stopped in OpenJDK 9+!
+				jreSuffix='/jre'
+			fi
 			cat >> "$dir/Dockerfile" <<-EOD
 
-				# see https://bugs.debian.org/775775
-				# and https://github.com/docker-library/java/issues/19#issuecomment-70546872
-				ENV CA_CERTIFICATES_JAVA_VERSION $caCertHackVersion
+				# do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
+				RUN ln -svT "/usr/lib/jvm/java-$javaVersion-openjdk-\$(dpkg --print-architecture)" /docker-java-home
+				ENV JAVA_HOME /docker-java-home$jreSuffix
+
+				ENV JAVA_VERSION $fullVersion
+				ENV JAVA_DEBIAN_VERSION $debianVersion
 			EOD
-		fi
 
-		sillyCaSymlink=$'\\'
-		sillyCaSymlinkCleanup=$'\\'
-		case "$javaVersion" in
-			10)
-				sillyCaSymlink+=$'\n# ca-certificates-java does not support src:openjdk-10 yet:\n# /etc/ca-certificates/update.d/jks-keystore: 86: /etc/ca-certificates/update.d/jks-keystore: java: not found\n\tln -svT /docker-java-home/bin/java /usr/local/bin/java; \\\n\t\\'
-				sillyCaSymlinkCleanup+=$'\n\trm -v /usr/local/bin/java; \\\n\t\\'
-				;;
-		esac
+			if [ "$needCaHack" ]; then
+				debian-latest-version 'ca-certificates-java' "$debSuite" > /dev/null # prime the cache
+				caCertHackVersion="$(debian-latest-version 'ca-certificates-java' "$debSuite")"
+				cat >> "$dir/Dockerfile" <<-EOD
 
-		cat >> "$dir/Dockerfile" <<EOD
+					# see https://bugs.debian.org/775775
+					# and https://github.com/docker-library/java/issues/19#issuecomment-70546872
+					ENV CA_CERTIFICATES_JAVA_VERSION $caCertHackVersion
+				EOD
+			fi
+
+			sillyCaSymlink=$'\\'
+			sillyCaSymlinkCleanup=$'\\'
+			case "$javaVersion" in
+				10)
+					sillyCaSymlink+=$'\n# ca-certificates-java does not support src:openjdk-10 yet:\n# /etc/ca-certificates/update.d/jks-keystore: 86: /etc/ca-certificates/update.d/jks-keystore: java: not found\n\tln -svT /docker-java-home/bin/java /usr/local/bin/java; \\\n\t\\'
+					sillyCaSymlinkCleanup+=$'\n\trm -v /usr/local/bin/java; \\\n\t\\'
+					;;
+			esac
+
+			cat >> "$dir/Dockerfile" <<EOD
 
 RUN set -ex; \\
 	\\
@@ -272,12 +273,12 @@ RUN set -ex; \\
 	apt-get install -y --no-install-recommends \\
 		$debianPackage="\$JAVA_DEBIAN_VERSION" \\
 EOD
-		if [ "$needCaHack" ]; then
-			cat >> "$dir/Dockerfile" <<EOD
+			if [ "$needCaHack" ]; then
+				cat >> "$dir/Dockerfile" <<EOD
 		ca-certificates-java="\$CA_CERTIFICATES_JAVA_VERSION" \\
 EOD
-		fi
-		cat >> "$dir/Dockerfile" <<EOD
+			fi
+			cat >> "$dir/Dockerfile" <<EOD
 	; \\
 	rm -rf /var/lib/apt/lists/*; \\
 	$sillyCaSymlinkCleanup
@@ -290,24 +291,25 @@ EOD
 	update-alternatives --query java | grep -q 'Status: manual'
 EOD
 
-		if [ "$needCaHack" ]; then
-			cat >> "$dir/Dockerfile" <<-EOD
+			if [ "$needCaHack" ]; then
+				cat >> "$dir/Dockerfile" <<-EOD
 
 				# see CA_CERTIFICATES_JAVA_VERSION notes above
 				RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
-			EOD
+				EOD
+			fi
+
+			if [ "$javaType" = 'jdk' ] && [ "$javaVersion" -ge 10 ]; then
+				cat >> "$dir/Dockerfile" <<-'EOD'
+
+					# https://docs.oracle.com/javase/10/tools/jshell.htm
+					# https://en.wikipedia.org/wiki/JShell
+					CMD ["jshell"]
+				EOD
+			fi
+
+			template-contribute-footer >> "$dir/Dockerfile"
 		fi
-
-		if [ "$javaType" = 'jdk' ] && [ "$javaVersion" -ge 10 ]; then
-			cat >> "$dir/Dockerfile" <<-'EOD'
-
-				# https://docs.oracle.com/javase/10/tools/jshell.htm
-				# https://en.wikipedia.org/wiki/JShell
-				CMD ["jshell"]
-			EOD
-		fi
-
-		template-contribute-footer >> "$dir/Dockerfile"
 
 		if [ -d "$dir/alpine" ]; then
 			alpineVersion="${alpineVersions[$javaVersion]:-$defaultAlpineVersion}"
@@ -376,58 +378,82 @@ EOD
 		fi
 
 		if [ -d "$dir/windows" ]; then
-			ojdkbuildVersion="$(
-				git ls-remote --tags 'https://github.com/ojdkbuild/ojdkbuild' \
-					| cut -d/ -f3 \
-					| grep -E '^(1[.])?'"$javaVersion"'[.-]' \
-					| sort -V \
-					| tail -1
-			)"
-			if [ -z "$ojdkbuildVersion" ]; then
-				echo >&2 "error: '$dir/windows' exists, but Java $javaVersion doesn't appear to have a corresponding ojdkbuild release"
-				exit 1
-			fi
-			ojdkbuildZip="$(
-				curl -fsSL "https://github.com/ojdkbuild/ojdkbuild/releases/tag/$ojdkbuildVersion" \
-					| grep --only-matching -E 'java-[0-9.]+-openjdk-[b0-9.-]+[.]ojdkbuild(ea)?[.]windows[.]x86_64[.]zip' \
-					| sort -u
-			)"
-			if [ -z "$ojdkbuildZip" ]; then
-				echo >&2 "error: $ojdkbuildVersion doesn't appear to have the release file we need (yet?)"
-				exit 1
-			fi
-			ojdkbuildSha256="$(curl -fsSL "https://github.com/ojdkbuild/ojdkbuild/releases/download/${ojdkbuildVersion}/${ojdkbuildZip}.sha256" | cut -d' ' -f1)"
-			if [ -z "$ojdkbuildSha256" ]; then
-				echo >&2 "error: $ojdkbuildVersion seems to have $ojdkbuildZip, but no sha256 for it"
-				exit 1
-			fi
+			case "$javaVersion" in
+				8 | 10)
+					ojdkbuildVersion="$(
+						git ls-remote --tags 'https://github.com/ojdkbuild/ojdkbuild' \
+							| cut -d/ -f3 \
+							| grep -E '^(1[.])?'"$javaVersion"'[.-]' \
+							| sort -V \
+							| tail -1
+					)"
+					if [ -z "$ojdkbuildVersion" ]; then
+						echo >&2 "error: '$dir/windows' exists, but Java $javaVersion doesn't appear to have a corresponding ojdkbuild release"
+						exit 1
+					fi
+					ojdkbuildZip="$(
+						curl -fsSL "https://github.com/ojdkbuild/ojdkbuild/releases/tag/$ojdkbuildVersion" \
+							| grep --only-matching -E 'java-[0-9.]+-openjdk-[b0-9.-]+[.]ojdkbuild(ea)?[.]windows[.]x86_64[.]zip' \
+							| sort -u
+					)"
+					if [ -z "$ojdkbuildZip" ]; then
+						echo >&2 "error: $ojdkbuildVersion doesn't appear to have the release file we need (yet?)"
+						exit 1
+					fi
+					ojdkbuildSha256="$(curl -fsSL "https://github.com/ojdkbuild/ojdkbuild/releases/download/${ojdkbuildVersion}/${ojdkbuildZip}.sha256" | cut -d' ' -f1)"
+					if [ -z "$ojdkbuildSha256" ]; then
+						echo >&2 "error: $ojdkbuildVersion seems to have $ojdkbuildZip, but no sha256 for it"
+						exit 1
+					fi
 
-			if [[ "$ojdkbuildVersion" == *-ea-* ]]; then
-				# convert "9-ea-b154-1" into "9-b154"
-				ojdkJavaVersion="$(echo "$ojdkbuildVersion" | sed -r 's/-ea-/-/' | cut -d- -f1,2)"
-			elif [[ "$ojdkbuildVersion" == 1.* ]]; then
-				# convert "1.8.0.111-3" into "8u111"
-				ojdkJavaVersion="$(echo "$ojdkbuildVersion" | cut -d. -f2,4 | cut -d- -f1 | tr . u)"
-			elif [[ "$ojdkbuildVersion" == 10.* ]]; then
-				# convert "10.0.1-1.b10" into "10.0.1"
-				ojdkJavaVersion="${ojdkbuildVersion%%-*}"
-			else
-				echo >&2 "error: unable to parse ojdkbuild version $ojdkbuildVersion"
-				exit 1
-			fi
+					if [[ "$ojdkbuildVersion" == *-ea-* ]]; then
+						# convert "9-ea-b154-1" into "9-b154"
+						ojdkJavaVersion="$(echo "$ojdkbuildVersion" | sed -r 's/-ea-/-/' | cut -d- -f1,2)"
+					elif [[ "$ojdkbuildVersion" == 1.* ]]; then
+						# convert "1.8.0.111-3" into "8u111"
+						ojdkJavaVersion="$(echo "$ojdkbuildVersion" | cut -d. -f2,4 | cut -d- -f1 | tr . u)"
+					elif [[ "$ojdkbuildVersion" == 10.* ]]; then
+						# convert "10.0.1-1.b10" into "10.0.1"
+						ojdkJavaVersion="${ojdkbuildVersion%%-*}"
+					else
+						echo >&2 "error: unable to parse ojdkbuild version $ojdkbuildVersion"
+						exit 1
+					fi
 
-			echo "$javaVersion-$javaType: $ojdkJavaVersion (windows ojdkbuild $ojdkbuildVersion)"
+					echo "$javaVersion-$javaType: $ojdkJavaVersion (windows ojdkbuild $ojdkbuildVersion)"
 
-			sed -ri \
-				-e 's/^(ENV JAVA_VERSION) .*/\1 '"$ojdkJavaVersion"'/' \
-				-e 's/^(ENV JAVA_OJDKBUILD_VERSION) .*/\1 '"$ojdkbuildVersion"'/' \
-				-e 's/^(ENV JAVA_OJDKBUILD_ZIP) .*/\1 '"$ojdkbuildZip"'/' \
-				-e 's/^(ENV JAVA_OJDKBUILD_SHA256) .*/\1 '"$ojdkbuildSha256"'/' \
-				"$dir"/windows/*/Dockerfile
+					sed -ri \
+						-e 's/^(ENV JAVA_VERSION) .*/\1 '"$ojdkJavaVersion"'/' \
+						-e 's/^(ENV JAVA_OJDKBUILD_VERSION) .*/\1 '"$ojdkbuildVersion"'/' \
+						-e 's/^(ENV JAVA_OJDKBUILD_ZIP) .*/\1 '"$ojdkbuildZip"'/' \
+						-e 's/^(ENV JAVA_OJDKBUILD_SHA256) .*/\1 '"$ojdkbuildSha256"'/' \
+						"$dir"/windows/*/Dockerfile
+					;;
+
+				*)
+					downloadUrl="$(
+						curl -fsSL "http://jdk.java.net/$javaVersion/" \
+							| tac|tac \
+							| grep -Eom1 'https://download.java.net/[^"]+_windows-x64_bin.zip'
+					)"
+					downloadSha256="$(curl -fsSL "$downloadUrl.sha256")"
+					downloadVersion="$(grep -Eom1 "openjdk-$javaVersion[^_]+" <<<"$downloadUrl")"
+					downloadVersion="${downloadVersion#openjdk-}"
+
+					echo "$javaVersion-$javaType: $downloadVersion (windows)"
+
+					sed -ri \
+						-e 's!^(ENV JAVA_VERSION) .*!\1 '"$downloadVersion"'!' \
+						-e 's!^(ENV JAVA_URL) .*!\1 '"$downloadUrl"'!' \
+						-e 's!^(ENV JAVA_SHA256) .*!\1 '"$downloadSha256"'!' \
+						-e 's!^(ENV JAVA_HOME) .*!\1 C:\\\\jdk-'"$javaVersion"'!' \
+						"$dir"/windows/*/Dockerfile
+					;;
+			esac
 
 			for winVariant in \
-				nanoserver-{1709,sac2016} \
-				windowsservercore-{1709,ltsc2016} \
+				nanoserver-{1803,1709,sac2016} \
+				windowsservercore-{1803,1709,ltsc2016} \
 			; do
 				[ -f "$dir/windows/$winVariant/Dockerfile" ] || continue
 
@@ -436,7 +462,7 @@ EOD
 					"$dir/windows/$winVariant/Dockerfile"
 
 				case "$winVariant" in
-					*-1709) ;; # no AppVeyor support for 1709 yet: https://github.com/appveyor/ci/issues/1885
+					*-1709 | *-1803 ) ;; # no AppVeyor support for 1709+ yet: https://github.com/appveyor/ci/issues/1885
 					*) appveyorEnv='\n    - version: '"$javaVersion"'\n      variant: '"$winVariant$appveyorEnv" ;;
 				esac
 			done
@@ -449,7 +475,9 @@ EOD
 	if [ -d "$javaVersion/jdk/slim" ]; then
 		travisEnv='\n  - VERSION='"$javaVersion"' VARIANT=slim'"$travisEnv"
 	fi
-	travisEnv='\n  - VERSION='"$javaVersion$travisEnv"
+	if [ -e "$javaVersion/jdk/Dockerfile" ]; then
+		travisEnv='\n  - VERSION='"$javaVersion$travisEnv"
+	fi
 done
 
 travis="$(awk -v 'RS=\n\n' '$1 == "env:" { $0 = "env:'"$travisEnv"'" } { printf "%s%s", $0, RS }' .travis.yml)"


### PR DESCRIPTION
This is the first half of https://github.com/docker-library/openjdk/issues/212 -- Windows is easier, especially if we only do 11 and 12 (since those don't exist yet).

This also allows Windows to get a one-up on Debian and Alpine by supporting 12. :muscle: