### PR TITLE
Create Dockerfile for nanoserver:sac2016 for openjdk 11

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,8 @@ environment:
       variant: windowsservercore-ltsc2016
     - version: 11
       variant: windowsservercore-ltsc2016
+    - version: 11
+      variant: nanoserver-sac2016
     - version: 10
       variant: windowsservercore-ltsc2016
     - version: 10

--- a/11/jdk/windows/nanoserver-sac2016/Dockerfile
+++ b/11/jdk/windows/nanoserver-sac2016/Dockerfile
@@ -1,0 +1,60 @@
+FROM microsoft/nanoserver:sac2016
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# enable TLS 1.2 (Nano Server doesn't support using "[Net.ServicePointManager]::SecurityProtocol")
+# https://docs.microsoft.com/en-us/system-center/vmm/install-tls?view=sc-vmm-1801
+# https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs#enable-tls-12
+RUN Write-Host 'Enabling TLS 1.2 (https://githubengineering.com/crypto-removal-notice/) ...'; \
+	$tls12RegBase = 'HKLM:\\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2'; \
+	if (Test-Path $tls12RegBase) { throw ('"{0}" already exists!' -f $tls12RegBase) }; \
+	New-Item -Path ('{0}/Client' -f $tls12RegBase) -Force; \
+	New-Item -Path ('{0}/Server' -f $tls12RegBase) -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force
+
+ENV JAVA_HOME C:\\ojdkbuild
+RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+# Nano Server does not have "[Environment]::SetEnvironmentVariable()"
+	setx /M PATH $newPath;
+
+# https://github.com/ojdkbuild/ojdkbuild/releases
+ENV JAVA_VERSION 11
+ENV JAVA_OJDKBUILD_VERSION 11.0.1-1
+ENV JAVA_OJDKBUILD_ZIP java-11-openjdk-11.0.1.13-1.ojdkbuild.windows.x86_64.zip
+ENV JAVA_OJDKBUILD_SHA256 a02cc84ba0fbb0a4d8acc48b5d2e6a9e5b447fee6d005096e2010f333db6af85
+
+RUN $url = ('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/{1}' -f $env:JAVA_OJDKBUILD_VERSION, $env:JAVA_OJDKBUILD_ZIP); \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	Invoke-WebRequest -Uri $url -OutFile 'ojdkbuild.zip'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_OJDKBUILD_SHA256); \
+	if ((Get-FileHash ojdkbuild.zip -Algorithm sha256).Hash -ne $env:JAVA_OJDKBUILD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive ojdkbuild.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Renaming ...'; \
+	Move-Item \
+		-Path ('C:\{0}' -f ($env:JAVA_OJDKBUILD_ZIP -Replace '.zip$', '')) \
+		-Destination $env:JAVA_HOME \
+	; \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  java --version'; java --version; \
+	Write-Host '  javac --version'; javac --version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item ojdkbuild.zip -Force; \
+	\
+	Write-Host 'Complete.';
+
+# https://docs.oracle.com/javase/10/tools/jshell.htm
+# https://en.wikipedia.org/wiki/JShell
+CMD ["jshell"]


### PR DESCRIPTION
This is basically a copy of https://github.com/docker-library/openjdk/blob/master/10/jdk/windows/nanoserver-sac2016/Dockerfile updating versions numbers to get the correct jdk version.