### PR TITLE
Add Java 11 image for nanoserver:sac2016

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,8 @@ environment:
       variant: windowsservercore-ltsc2016
     - version: 11
       variant: windowsservercore-ltsc2016
+    - version: 11
+      variant: nanoserver-sac2016
     - version: 8
       variant: windowsservercore-ltsc2016
     - version: 8

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,6 +5,8 @@ environment:
   matrix:
     - version: 12
       variant: windowsservercore-ltsc2016
+    - version: 12
+      variant: nanoserver-sac2016
     - version: 11
       variant: windowsservercore-ltsc2016
     - version: 11

--- a/11/jdk/windows/nanoserver-sac2016/Dockerfile
+++ b/11/jdk/windows/nanoserver-sac2016/Dockerfile
@@ -1,4 +1,4 @@
-FROM placeholder
+FROM microsoft/nanoserver:sac2016
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
@@ -16,16 +16,16 @@ RUN Write-Host 'Enabling TLS 1.2 (https://githubengineering.com/crypto-removal-n
 	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
 	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force
 
-ENV JAVA_HOME placeholder
+ENV JAVA_HOME C:\\openjdk-11
 RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
 	Write-Host ('Updating PATH: {0}' -f $newPath); \
 # Nano Server does not have "[Environment]::SetEnvironmentVariable()"
 	setx /M PATH $newPath
 
 # http://jdk.java.net/
-ENV JAVA_VERSION placeholder
-ENV JAVA_URL placeholder
-ENV JAVA_SHA256 placeholder
+ENV JAVA_VERSION 11.0.1
+ENV JAVA_URL https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_windows-x64_bin.zip
+ENV JAVA_SHA256 289dd06e06c2cbd5e191f2d227c9338e88b6963fd0c75bceb9be48f0394ede21
 
 RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
 	Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.zip'; \

--- a/11/jdk/windows/windowsservercore-1709/Dockerfile
+++ b/11/jdk/windows/windowsservercore-1709/Dockerfile
@@ -3,6 +3,19 @@ FROM microsoft/windowsservercore:1709
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# enable TLS 1.2 (Nano Server doesn't support using "[Net.ServicePointManager]::SecurityProtocol")
+# https://docs.microsoft.com/en-us/system-center/vmm/install-tls?view=sc-vmm-1801
+# https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs#enable-tls-12
+RUN Write-Host 'Enabling TLS 1.2 (https://githubengineering.com/crypto-removal-notice/) ...'; \
+	$tls12RegBase = 'HKLM:\\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2'; \
+	if (Test-Path $tls12RegBase) { throw ('"{0}" already exists!' -f $tls12RegBase) }; \
+	New-Item -Path ('{0}/Client' -f $tls12RegBase) -Force; \
+	New-Item -Path ('{0}/Server' -f $tls12RegBase) -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force
+
 ENV JAVA_HOME C:\\openjdk-11
 RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
 	Write-Host ('Updating PATH: {0}' -f $newPath); \
@@ -15,7 +28,6 @@ ENV JAVA_URL https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_windo
 ENV JAVA_SHA256 289dd06e06c2cbd5e191f2d227c9338e88b6963fd0c75bceb9be48f0394ede21
 
 RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.zip'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
 	if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \

--- a/11/jdk/windows/windowsservercore-1803/Dockerfile
+++ b/11/jdk/windows/windowsservercore-1803/Dockerfile
@@ -3,6 +3,19 @@ FROM microsoft/windowsservercore:1803
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# enable TLS 1.2 (Nano Server doesn't support using "[Net.ServicePointManager]::SecurityProtocol")
+# https://docs.microsoft.com/en-us/system-center/vmm/install-tls?view=sc-vmm-1801
+# https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs#enable-tls-12
+RUN Write-Host 'Enabling TLS 1.2 (https://githubengineering.com/crypto-removal-notice/) ...'; \
+	$tls12RegBase = 'HKLM:\\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2'; \
+	if (Test-Path $tls12RegBase) { throw ('"{0}" already exists!' -f $tls12RegBase) }; \
+	New-Item -Path ('{0}/Client' -f $tls12RegBase) -Force; \
+	New-Item -Path ('{0}/Server' -f $tls12RegBase) -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force
+
 ENV JAVA_HOME C:\\openjdk-11
 RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
 	Write-Host ('Updating PATH: {0}' -f $newPath); \
@@ -15,7 +28,6 @@ ENV JAVA_URL https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_windo
 ENV JAVA_SHA256 289dd06e06c2cbd5e191f2d227c9338e88b6963fd0c75bceb9be48f0394ede21
 
 RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.zip'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
 	if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \

--- a/11/jdk/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/11/jdk/windows/windowsservercore-ltsc2016/Dockerfile
@@ -3,6 +3,19 @@ FROM microsoft/windowsservercore:ltsc2016
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# enable TLS 1.2 (Nano Server doesn't support using "[Net.ServicePointManager]::SecurityProtocol")
+# https://docs.microsoft.com/en-us/system-center/vmm/install-tls?view=sc-vmm-1801
+# https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs#enable-tls-12
+RUN Write-Host 'Enabling TLS 1.2 (https://githubengineering.com/crypto-removal-notice/) ...'; \
+	$tls12RegBase = 'HKLM:\\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2'; \
+	if (Test-Path $tls12RegBase) { throw ('"{0}" already exists!' -f $tls12RegBase) }; \
+	New-Item -Path ('{0}/Client' -f $tls12RegBase) -Force; \
+	New-Item -Path ('{0}/Server' -f $tls12RegBase) -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force
+
 ENV JAVA_HOME C:\\openjdk-11
 RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
 	Write-Host ('Updating PATH: {0}' -f $newPath); \
@@ -15,7 +28,6 @@ ENV JAVA_URL https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_windo
 ENV JAVA_SHA256 289dd06e06c2cbd5e191f2d227c9338e88b6963fd0c75bceb9be48f0394ede21
 
 RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.zip'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
 	if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \

--- a/12/jdk/windows/nanoserver-sac2016/Dockerfile
+++ b/12/jdk/windows/nanoserver-sac2016/Dockerfile
@@ -1,0 +1,55 @@
+FROM microsoft/nanoserver:sac2016
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# enable TLS 1.2 (Nano Server doesn't support using "[Net.ServicePointManager]::SecurityProtocol")
+# https://docs.microsoft.com/en-us/system-center/vmm/install-tls?view=sc-vmm-1801
+# https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs#enable-tls-12
+RUN Write-Host 'Enabling TLS 1.2 (https://githubengineering.com/crypto-removal-notice/) ...'; \
+	$tls12RegBase = 'HKLM:\\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2'; \
+	if (Test-Path $tls12RegBase) { throw ('"{0}" already exists!' -f $tls12RegBase) }; \
+	New-Item -Path ('{0}/Client' -f $tls12RegBase) -Force; \
+	New-Item -Path ('{0}/Server' -f $tls12RegBase) -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force
+
+ENV JAVA_HOME C:\\openjdk-12
+RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+# Nano Server does not have "[Environment]::SetEnvironmentVariable()"
+	setx /M PATH $newPath
+
+# http://jdk.java.net/
+ENV JAVA_VERSION 12-ea+25
+ENV JAVA_URL https://download.java.net/java/early_access/jdk12/25/GPL/openjdk-12-ea+25_windows-x64_bin.zip
+ENV JAVA_SHA256 a3c94a495ea402b6c752c5757dcd902ec497720d52f59cee756975615a0661c3
+
+RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
+	Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.zip'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
+	if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	New-Item -ItemType Directory -Path C:\temp | Out-Null; \
+	Expand-Archive openjdk.zip -DestinationPath C:\temp; \
+	Move-Item -Path C:\temp\* -Destination $env:JAVA_HOME; \
+	Remove-Item C:\temp; \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  java --version'; java --version; \
+	Write-Host '  javac --version'; javac --version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item openjdk.zip -Force; \
+	\
+	Write-Host 'Complete.'
+
+# https://docs.oracle.com/javase/10/tools/jshell.htm
+# https://en.wikipedia.org/wiki/JShell
+CMD ["jshell"]

--- a/12/jdk/windows/windowsservercore-1709/Dockerfile
+++ b/12/jdk/windows/windowsservercore-1709/Dockerfile
@@ -3,6 +3,19 @@ FROM microsoft/windowsservercore:1709
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# enable TLS 1.2 (Nano Server doesn't support using "[Net.ServicePointManager]::SecurityProtocol")
+# https://docs.microsoft.com/en-us/system-center/vmm/install-tls?view=sc-vmm-1801
+# https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs#enable-tls-12
+RUN Write-Host 'Enabling TLS 1.2 (https://githubengineering.com/crypto-removal-notice/) ...'; \
+	$tls12RegBase = 'HKLM:\\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2'; \
+	if (Test-Path $tls12RegBase) { throw ('"{0}" already exists!' -f $tls12RegBase) }; \
+	New-Item -Path ('{0}/Client' -f $tls12RegBase) -Force; \
+	New-Item -Path ('{0}/Server' -f $tls12RegBase) -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force
+
 ENV JAVA_HOME C:\\openjdk-12
 RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
 	Write-Host ('Updating PATH: {0}' -f $newPath); \
@@ -15,7 +28,6 @@ ENV JAVA_URL https://download.java.net/java/early_access/jdk12/25/GPL/openjdk-12
 ENV JAVA_SHA256 a3c94a495ea402b6c752c5757dcd902ec497720d52f59cee756975615a0661c3
 
 RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.zip'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
 	if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \

--- a/12/jdk/windows/windowsservercore-1803/Dockerfile
+++ b/12/jdk/windows/windowsservercore-1803/Dockerfile
@@ -3,6 +3,19 @@ FROM microsoft/windowsservercore:1803
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# enable TLS 1.2 (Nano Server doesn't support using "[Net.ServicePointManager]::SecurityProtocol")
+# https://docs.microsoft.com/en-us/system-center/vmm/install-tls?view=sc-vmm-1801
+# https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs#enable-tls-12
+RUN Write-Host 'Enabling TLS 1.2 (https://githubengineering.com/crypto-removal-notice/) ...'; \
+	$tls12RegBase = 'HKLM:\\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2'; \
+	if (Test-Path $tls12RegBase) { throw ('"{0}" already exists!' -f $tls12RegBase) }; \
+	New-Item -Path ('{0}/Client' -f $tls12RegBase) -Force; \
+	New-Item -Path ('{0}/Server' -f $tls12RegBase) -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force
+
 ENV JAVA_HOME C:\\openjdk-12
 RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
 	Write-Host ('Updating PATH: {0}' -f $newPath); \
@@ -15,7 +28,6 @@ ENV JAVA_URL https://download.java.net/java/early_access/jdk12/25/GPL/openjdk-12
 ENV JAVA_SHA256 a3c94a495ea402b6c752c5757dcd902ec497720d52f59cee756975615a0661c3
 
 RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.zip'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
 	if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \

--- a/12/jdk/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/12/jdk/windows/windowsservercore-ltsc2016/Dockerfile
@@ -3,6 +3,19 @@ FROM microsoft/windowsservercore:ltsc2016
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# enable TLS 1.2 (Nano Server doesn't support using "[Net.ServicePointManager]::SecurityProtocol")
+# https://docs.microsoft.com/en-us/system-center/vmm/install-tls?view=sc-vmm-1801
+# https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs#enable-tls-12
+RUN Write-Host 'Enabling TLS 1.2 (https://githubengineering.com/crypto-removal-notice/) ...'; \
+	$tls12RegBase = 'HKLM:\\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2'; \
+	if (Test-Path $tls12RegBase) { throw ('"{0}" already exists!' -f $tls12RegBase) }; \
+	New-Item -Path ('{0}/Client' -f $tls12RegBase) -Force; \
+	New-Item -Path ('{0}/Server' -f $tls12RegBase) -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force
+
 ENV JAVA_HOME C:\\openjdk-12
 RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
 	Write-Host ('Updating PATH: {0}' -f $newPath); \
@@ -15,7 +28,6 @@ ENV JAVA_URL https://download.java.net/java/early_access/jdk12/25/GPL/openjdk-12
 ENV JAVA_SHA256 a3c94a495ea402b6c752c5757dcd902ec497720d52f59cee756975615a0661c3
 
 RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.zip'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
 	if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \

--- a/update.sh
+++ b/update.sh
@@ -467,9 +467,10 @@ EOD
 					for winD in "$dir"/windows/*/; do
 						winD="${winD%/}"
 						windowsVersion="$(basename "$winD")"
-						windowsVersion="${windowsVersion#windowsservercore-}"
+						windowsVariant="${windowsVersion%%-*}" # "windowsservercore", "nanoserver"
+						windowsVersion="${windowsVersion#$windowsVariant-}" # "1803", "ltsc2016", etc
 						sed -r \
-							-e 's!^(FROM microsoft/windowsservercore):.*$!\1:'"$windowsVersion"'!' \
+							-e 's!^(FROM) .*$!\1 microsoft/'"$windowsVariant"':'"$windowsVersion"'!' \
 							-e 's!^(ENV JAVA_HOME) .*!\1 C:\\\\openjdk-'"$javaVersion"'!' \
 							-e 's!^(ENV JAVA_VERSION) .*!\1 '"$downloadVersion"'!' \
 							-e 's!^(ENV JAVA_URL) .*!\1 '"$downloadUrl"'!' \


### PR DESCRIPTION
Adding a java 11 image voor nanoserver, so we can use this one instead of the windows server core image.

Fixes #258