### PR TITLE
Add java 8 en java 11 images for nanoserver 1809

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,6 +19,8 @@ environment:
       variant: windowsservercore-ltsc2016
     - version: 8
       variant: nanoserver-sac2016
+    - version: 8
+      variant: nanoserver-1809
 
 install:
   - ps: |

--- a/11/jdk/windows/nanoserver-1809/Dockerfile
+++ b/11/jdk/windows/nanoserver-1809/Dockerfile
@@ -1,0 +1,63 @@
+FROM mcr.microsoft.com/powershell:6.1.3-nanoserver-1809	as builder
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+USER ContainerAdministrator
+
+# enable TLS 1.2 (Nano Server doesn't support using "[Net.ServicePointManager]::SecurityProtocol")
+# https://docs.microsoft.com/en-us/system-center/vmm/install-tls?view=sc-vmm-1801
+# https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs#enable-tls-12
+RUN Write-Host 'Enabling TLS 1.2 (https://githubengineering.com/crypto-removal-notice/) ...'; \
+	$tls12RegBase = 'HKLM:\\\\SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\SCHANNEL\\Protocols\\TLS 1.2'; \
+	if (Test-Path $tls12RegBase) { throw ('"{0}" already exists!' -f $tls12RegBase) }; \
+	New-Item -Path ('{0}/Client' -f $tls12RegBase) -Force; \
+	New-Item -Path ('{0}/Server' -f $tls12RegBase) -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force
+
+ENV JAVA_HOME=C:\\openjdk-11 \
+# https://jdk.java.net/
+ 	JAVA_VERSION=11.0.2 \
+	JAVA_URL=https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_windows-x64_bin.zip \
+	JAVA_SHA256=cf39490fe042dba1b61d6e9a395095279a69e70086c8c8d5466d9926d80976d8
+
+RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
+	Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.zip'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
+	if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	New-Item -ItemType Directory -Path C:\temp | Out-Null; \
+	Expand-Archive openjdk.zip -DestinationPath C:\temp; \
+	Move-Item -Path C:\temp\* -Destination $env:JAVA_HOME; \
+	Remove-Item C:\temp; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item openjdk.zip -Force; \
+	\
+	Write-Host 'Complete.'
+
+FROM mcr.microsoft.com/windows/nanoserver:1809_amd64 as runtime
+COPY --from=builder openjdk-11 openjdk-11
+ENV JAVA_VERSION=11.0.2 \
+	JAVA_HOME=C:\\openjdk-11 \
+	# Set the default windows path so we can use it
+    WindowsPATH="C:\Windows\system32;C:\Windows"
+ENV Path="${WindowsPATH};${JAVA_HOME}\bin"
+
+FROM runtime as verifier
+RUN \
+	echo 'Verifying install ...' && \
+	echo '  java --version' && java --version && \
+	echo '  javac --version' && javac --version || exit 1
+
+FROM runtime as final
+# https://docs.oracle.com/javase/10/tools/jshell.htm
+# https://en.wikipedia.org/wiki/JShell
+CMD ["jshell"]

--- a/8/jdk/windows/nanoserver-1809/Dockerfile
+++ b/8/jdk/windows/nanoserver-1809/Dockerfile
@@ -1,0 +1,65 @@
+FROM mcr.microsoft.com/powershell:6.1.3-nanoserver-1809	as builder
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+USER ContainerAdministrator
+
+# enable TLS 1.2 (Nano Server doesn't support using "[Net.ServicePointManager]::SecurityProtocol")
+# https://docs.microsoft.com/en-us/system-center/vmm/install-tls?view=sc-vmm-1801
+# https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs#enable-tls-12
+RUN Write-Host 'Enabling TLS 1.2 (https://githubengineering.com/crypto-removal-notice/) ...'; \
+	$tls12RegBase = 'HKLM:\\\\SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\SCHANNEL\\Protocols\\TLS 1.2'; \
+	if (Test-Path $tls12RegBase) { throw ('"{0}" already exists!' -f $tls12RegBase) }; \
+	New-Item -Path ('{0}/Client' -f $tls12RegBase) -Force; \
+	New-Item -Path ('{0}/Server' -f $tls12RegBase) -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force
+
+ENV JAVA_HOME=C:\\openjdk-8 \
+# https://jdk.java.net/
+	JAVA_VERSION=8u201 \
+	JAVA_OJDKBUILD_VERSION=1.8.0.201-1 \
+	JAVA_OJDKBUILD_ZIP=java-1.8.0-openjdk-1.8.0.201-1.b09.ojdkbuild.windows.x86_64.zip \
+	JAVA_OJDKBUILD_SHA256=d74066dc7d6e017388b1eeeb4f4cc0af20337aa6eea8e3a818017ae8d15b988a
+
+RUN $url = ('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/{1}' -f $env:JAVA_OJDKBUILD_VERSION, $env:JAVA_OJDKBUILD_ZIP); \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	Invoke-WebRequest -Uri $url -OutFile 'openjdk.zip'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_OJDKBUILD_SHA256); \
+	if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_OJDKBUILD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	New-Item -ItemType Directory -Path C:\temp | Out-Null; \
+	Expand-Archive openjdk.zip -DestinationPath C:\temp; \
+	Move-Item -Path C:\temp\* -Destination $env:JAVA_HOME; \
+	Remove-Item C:\temp; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item openjdk.zip -Force; \
+	\
+	Write-Host 'Complete.'
+
+FROM mcr.microsoft.com/windows/nanoserver:1809_amd64 as runtime
+COPY --from=builder openjdk-8 openjdk-8
+ENV JAVA_VERSION=8u201 \
+	JAVA_HOME=C:\\openjdk-8 \
+	# Set the default windows path so we can use it
+    WindowsPATH="C:\Windows\system32;C:\Windows"
+ENV Path="${WindowsPATH};${JAVA_HOME}\bin"
+
+FROM runtime as verifier
+RUN \
+	echo 'Verifying install ...' && \
+	echo '  java --version' && java -version \
+	echo '  javac --version' && javac -version || exit 1
+
+FROM runtime as final
+# https://docs.oracle.com/javase/10/tools/jshell.htm
+# https://en.wikipedia.org/wiki/JShell
+CMD ["jshell"]


### PR DESCRIPTION
Adding java 8 and 11 images for windows nanoserver 1809
There are currently only Windows Server Core 2016 images available for java 8 and 11.
Since nanoserver is smaller and faster than Windows Server Core, these images bring a better performance.

The images are build multistage, so they are as small as possible.
The verify installer step checks if java and javac can be called from the command line and exists the build process if not found.