### PR TITLE
Update "latest" to OpenJDK 12

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,8 +2,8 @@
 set -Eeuo pipefail
 
 declare -A aliases=(
-	[11-jdk]='jdk latest'
-	[11-jre]='jre'
+	[12-jdk]='jdk latest'
+	[12-jre]='jre'
 )
 defaultType='jdk'
 


### PR DESCRIPTION
12 is now GA; https://jdk.java.net/, https://jdk.java.net/12/