### PR TITLE
start using adoptopenjdk windows MSI's

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,8 @@ environment:
       variant: windowsservercore-ltsc2016
     - version: 12
       variant: windowsservercore-ltsc2016
+    - version: 11
+      variant: windowsservercore-ltsc2016
     - version: 8
       variant: windowsservercore-ltsc2016
 
@@ -14,7 +16,6 @@ install:
   - ps: |
       [Environment]::SetEnvironmentVariable('dockerImage', ('openjdk:{0}' -f $env:version), [EnvironmentVariableTarget]::Process);
       [Environment]::SetEnvironmentVariable('buildDirectory', ('{0}/jdk/windows/{1}' -f $env:version, $env:variant), [EnvironmentVariableTarget]::Process);
-
 build_script:
   - cmd: appveyor-retry docker build --pull -t %dockerImage% %buildDirectory%
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
       env: VERSION=11
     - os: linux
       env: VERSION=11 VARIANT=slim
+    - os: windows
+      dist: 1803-containers
+      env: VERSION=11 VARIANT=windows/windowsservercore-1803
     - os: linux
       env: VERSION=8
     - os: linux
@@ -67,7 +70,6 @@ script:
         fi
       fi
     )
-
 after_script:
   - docker images
 

--- a/11/jdk/windows/windowsservercore-1803/Dockerfile
+++ b/11/jdk/windows/windowsservercore-1803/Dockerfile
@@ -1,12 +1,12 @@
-FROM mcr.microsoft.com/windows/servercore:1809
+FROM mcr.microsoft.com/windows/servercore:1803
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # https://adoptopenjdk.net/
-ENV JAVA_VERSION 8.0.212+3
-ENV JAVA_URL https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03/OpenJDK8U-jdk_x64_windows_hotspot_8u212b03.msi
-ENV JAVA_SHA256 86cf932a04dff28e19a5f715cbb8f2c34ce78fa12d30578bcaf7fb46f88a3acb
+ENV JAVA_VERSION 11.0.3+7
+ENV JAVA_URL https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jdk_x64_windows_hotspot_11.0.3_7.msi
+ENV JAVA_SHA256 6eb277a3e9305fdf380900d20f4ef7a474f13fdbc92f7709b57945f6ffdc80fc
 
 RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -29,3 +29,7 @@ RUN Write-Host 'Verifying install ...'; \
         Write-Host '  java -version'; java -version; \
         Write-Host '  javac -version'; javac -version; \
         Write-Host '  JAVA_HOME'; Test-Path $env:JAVA_HOME;
+
+# https://docs.oracle.com/javase/10/tools/jshell.htm
+# https://en.wikipedia.org/wiki/JShell
+CMD ["jshell"]

--- a/11/jdk/windows/windowsservercore-1809/Dockerfile
+++ b/11/jdk/windows/windowsservercore-1809/Dockerfile
@@ -4,9 +4,9 @@ FROM mcr.microsoft.com/windows/servercore:1809
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # https://adoptopenjdk.net/
-ENV JAVA_VERSION 8.0.212+3
-ENV JAVA_URL https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03/OpenJDK8U-jdk_x64_windows_hotspot_8u212b03.msi
-ENV JAVA_SHA256 86cf932a04dff28e19a5f715cbb8f2c34ce78fa12d30578bcaf7fb46f88a3acb
+ENV JAVA_VERSION 11.0.3+7
+ENV JAVA_URL https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jdk_x64_windows_hotspot_11.0.3_7.msi
+ENV JAVA_SHA256 6eb277a3e9305fdf380900d20f4ef7a474f13fdbc92f7709b57945f6ffdc80fc
 
 RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -29,3 +29,7 @@ RUN Write-Host 'Verifying install ...'; \
         Write-Host '  java -version'; java -version; \
         Write-Host '  javac -version'; javac -version; \
         Write-Host '  JAVA_HOME'; Test-Path $env:JAVA_HOME;
+
+# https://docs.oracle.com/javase/10/tools/jshell.htm
+# https://en.wikipedia.org/wiki/JShell
+CMD ["jshell"]

--- a/11/jdk/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/11/jdk/windows/windowsservercore-ltsc2016/Dockerfile
@@ -1,12 +1,12 @@
-FROM mcr.microsoft.com/windows/servercore:1809
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # https://adoptopenjdk.net/
-ENV JAVA_VERSION 8.0.212+3
-ENV JAVA_URL https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03/OpenJDK8U-jdk_x64_windows_hotspot_8u212b03.msi
-ENV JAVA_SHA256 86cf932a04dff28e19a5f715cbb8f2c34ce78fa12d30578bcaf7fb46f88a3acb
+ENV JAVA_VERSION 11.0.3+7
+ENV JAVA_URL https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jdk_x64_windows_hotspot_11.0.3_7.msi
+ENV JAVA_SHA256 6eb277a3e9305fdf380900d20f4ef7a474f13fdbc92f7709b57945f6ffdc80fc
 
 RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -29,3 +29,7 @@ RUN Write-Host 'Verifying install ...'; \
         Write-Host '  java -version'; java -version; \
         Write-Host '  javac -version'; javac -version; \
         Write-Host '  JAVA_HOME'; Test-Path $env:JAVA_HOME;
+
+# https://docs.oracle.com/javase/10/tools/jshell.htm
+# https://en.wikipedia.org/wiki/JShell
+CMD ["jshell"]

--- a/12/jdk/windows/windowsservercore-1803/Dockerfile
+++ b/12/jdk/windows/windowsservercore-1803/Dockerfile
@@ -3,52 +3,32 @@ FROM mcr.microsoft.com/windows/servercore:1803
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# enable TLS 1.2 (Nano Server doesn't support using "[Net.ServicePointManager]::SecurityProtocol")
-# https://docs.microsoft.com/en-us/system-center/vmm/install-tls?view=sc-vmm-1801
-# https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs#enable-tls-12
-RUN Write-Host 'Enabling TLS 1.2 (https://githubengineering.com/crypto-removal-notice/) ...'; \
-	$tls12RegBase = 'HKLM:\\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2'; \
-	if (Test-Path $tls12RegBase) { throw ('"{0}" already exists!' -f $tls12RegBase) }; \
-	New-Item -Path ('{0}/Client' -f $tls12RegBase) -Force; \
-	New-Item -Path ('{0}/Server' -f $tls12RegBase) -Force; \
-	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
-	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force; \
-	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
-	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force
-
-ENV JAVA_HOME C:\\openjdk-12
-RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
-	Write-Host ('Updating PATH: {0}' -f $newPath); \
-# Nano Server does not have "[Environment]::SetEnvironmentVariable()"
-	setx /M PATH $newPath
-
-# https://jdk.java.net/
-ENV JAVA_VERSION 12.0.1
-ENV JAVA_URL https://download.java.net/java/GA/jdk12.0.1/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-12.0.1_windows-x64_bin.zip
-ENV JAVA_SHA256 fc7d9eee3c09ea6548b00ca25dbf34a348b3942c815405a1428e0bfef268d08d
+# https://adoptopenjdk.net/
+ENV JAVA_VERSION 12.0.1+12
+ENV JAVA_URL https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.1%2B12/OpenJDK12U-jdk_x64_windows_hotspot_12.0.1_12.msi
+ENV JAVA_SHA256 c08f97625f0562889497b4cfc023bd06ada9554050c9b34c1050167fcf89847c
 
 RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
-	Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.zip'; \
-	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
-	if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \
-		Write-Host 'FAILED!'; \
-		exit 1; \
-	}; \
-	\
-	Write-Host 'Expanding ...'; \
-	New-Item -ItemType Directory -Path C:\temp | Out-Null; \
-	Expand-Archive openjdk.zip -DestinationPath C:\temp; \
-	Move-Item -Path C:\temp\* -Destination $env:JAVA_HOME; \
-	Remove-Item C:\temp; \
-	\
-	Write-Host 'Verifying install ...'; \
-	Write-Host '  java --version'; java --version; \
-	Write-Host '  javac --version'; javac --version; \
-	\
-	Write-Host 'Removing ...'; \
-	Remove-Item openjdk.zip -Force; \
-	\
-	Write-Host 'Complete.'
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \
+                Write-Host 'FAILED!'; \
+                exit 1; \
+        }; \
+        \
+        New-Item -ItemType Directory -Path C:\temp | Out-Null;
+
+RUN Write-Host 'Installing using MSI ...'; \
+        Start-Process -FilePath "msiexec.exe" -ArgumentList '/i', 'openjdk.msi', '/L*V', 'C:\temp\OpenJDK.log', \
+        '/quiet', 'ADDLOCAL=FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome' -Wait -Passthru; \
+        Write-Host 'Removing ...'; \
+        Remove-Item openjdk.msi -Force;
+
+RUN Write-Host 'Verifying install ...'; \
+        Write-Host '  java -version'; java -version; \
+        Write-Host '  javac -version'; javac -version; \
+        Write-Host '  JAVA_HOME'; Test-Path $env:JAVA_HOME;
 
 # https://docs.oracle.com/javase/10/tools/jshell.htm
 # https://en.wikipedia.org/wiki/JShell

--- a/12/jdk/windows/windowsservercore-1809/Dockerfile
+++ b/12/jdk/windows/windowsservercore-1809/Dockerfile
@@ -3,52 +3,32 @@ FROM mcr.microsoft.com/windows/servercore:1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# enable TLS 1.2 (Nano Server doesn't support using "[Net.ServicePointManager]::SecurityProtocol")
-# https://docs.microsoft.com/en-us/system-center/vmm/install-tls?view=sc-vmm-1801
-# https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs#enable-tls-12
-RUN Write-Host 'Enabling TLS 1.2 (https://githubengineering.com/crypto-removal-notice/) ...'; \
-	$tls12RegBase = 'HKLM:\\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2'; \
-	if (Test-Path $tls12RegBase) { throw ('"{0}" already exists!' -f $tls12RegBase) }; \
-	New-Item -Path ('{0}/Client' -f $tls12RegBase) -Force; \
-	New-Item -Path ('{0}/Server' -f $tls12RegBase) -Force; \
-	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
-	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force; \
-	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
-	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force
-
-ENV JAVA_HOME C:\\openjdk-12
-RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
-	Write-Host ('Updating PATH: {0}' -f $newPath); \
-# Nano Server does not have "[Environment]::SetEnvironmentVariable()"
-	setx /M PATH $newPath
-
-# https://jdk.java.net/
-ENV JAVA_VERSION 12.0.1
-ENV JAVA_URL https://download.java.net/java/GA/jdk12.0.1/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-12.0.1_windows-x64_bin.zip
-ENV JAVA_SHA256 fc7d9eee3c09ea6548b00ca25dbf34a348b3942c815405a1428e0bfef268d08d
+# https://adoptopenjdk.net/
+ENV JAVA_VERSION 12.0.1+12
+ENV JAVA_URL https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.1%2B12/OpenJDK12U-jdk_x64_windows_hotspot_12.0.1_12.msi
+ENV JAVA_SHA256 c08f97625f0562889497b4cfc023bd06ada9554050c9b34c1050167fcf89847c
 
 RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
-	Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.zip'; \
-	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
-	if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \
-		Write-Host 'FAILED!'; \
-		exit 1; \
-	}; \
-	\
-	Write-Host 'Expanding ...'; \
-	New-Item -ItemType Directory -Path C:\temp | Out-Null; \
-	Expand-Archive openjdk.zip -DestinationPath C:\temp; \
-	Move-Item -Path C:\temp\* -Destination $env:JAVA_HOME; \
-	Remove-Item C:\temp; \
-	\
-	Write-Host 'Verifying install ...'; \
-	Write-Host '  java --version'; java --version; \
-	Write-Host '  javac --version'; javac --version; \
-	\
-	Write-Host 'Removing ...'; \
-	Remove-Item openjdk.zip -Force; \
-	\
-	Write-Host 'Complete.'
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \
+                Write-Host 'FAILED!'; \
+                exit 1; \
+        }; \
+        \
+        New-Item -ItemType Directory -Path C:\temp | Out-Null;
+
+RUN Write-Host 'Installing using MSI ...'; \
+        Start-Process -FilePath "msiexec.exe" -ArgumentList '/i', 'openjdk.msi', '/L*V', 'C:\temp\OpenJDK.log', \
+        '/quiet', 'ADDLOCAL=FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome' -Wait -Passthru; \
+        Write-Host 'Removing ...'; \
+        Remove-Item openjdk.msi -Force;
+
+RUN Write-Host 'Verifying install ...'; \
+        Write-Host '  java -version'; java -version; \
+        Write-Host '  javac -version'; javac -version; \
+        Write-Host '  JAVA_HOME'; Test-Path $env:JAVA_HOME;
 
 # https://docs.oracle.com/javase/10/tools/jshell.htm
 # https://en.wikipedia.org/wiki/JShell

--- a/12/jdk/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/12/jdk/windows/windowsservercore-ltsc2016/Dockerfile
@@ -3,52 +3,32 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# enable TLS 1.2 (Nano Server doesn't support using "[Net.ServicePointManager]::SecurityProtocol")
-# https://docs.microsoft.com/en-us/system-center/vmm/install-tls?view=sc-vmm-1801
-# https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs#enable-tls-12
-RUN Write-Host 'Enabling TLS 1.2 (https://githubengineering.com/crypto-removal-notice/) ...'; \
-	$tls12RegBase = 'HKLM:\\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2'; \
-	if (Test-Path $tls12RegBase) { throw ('"{0}" already exists!' -f $tls12RegBase) }; \
-	New-Item -Path ('{0}/Client' -f $tls12RegBase) -Force; \
-	New-Item -Path ('{0}/Server' -f $tls12RegBase) -Force; \
-	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
-	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force; \
-	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
-	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force
-
-ENV JAVA_HOME C:\\openjdk-12
-RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
-	Write-Host ('Updating PATH: {0}' -f $newPath); \
-# Nano Server does not have "[Environment]::SetEnvironmentVariable()"
-	setx /M PATH $newPath
-
-# https://jdk.java.net/
-ENV JAVA_VERSION 12.0.1
-ENV JAVA_URL https://download.java.net/java/GA/jdk12.0.1/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-12.0.1_windows-x64_bin.zip
-ENV JAVA_SHA256 fc7d9eee3c09ea6548b00ca25dbf34a348b3942c815405a1428e0bfef268d08d
+# https://adoptopenjdk.net/
+ENV JAVA_VERSION 12.0.1+12
+ENV JAVA_URL https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.1%2B12/OpenJDK12U-jdk_x64_windows_hotspot_12.0.1_12.msi
+ENV JAVA_SHA256 c08f97625f0562889497b4cfc023bd06ada9554050c9b34c1050167fcf89847c
 
 RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
-	Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.zip'; \
-	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
-	if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \
-		Write-Host 'FAILED!'; \
-		exit 1; \
-	}; \
-	\
-	Write-Host 'Expanding ...'; \
-	New-Item -ItemType Directory -Path C:\temp | Out-Null; \
-	Expand-Archive openjdk.zip -DestinationPath C:\temp; \
-	Move-Item -Path C:\temp\* -Destination $env:JAVA_HOME; \
-	Remove-Item C:\temp; \
-	\
-	Write-Host 'Verifying install ...'; \
-	Write-Host '  java --version'; java --version; \
-	Write-Host '  javac --version'; javac --version; \
-	\
-	Write-Host 'Removing ...'; \
-	Remove-Item openjdk.zip -Force; \
-	\
-	Write-Host 'Complete.'
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \
+                Write-Host 'FAILED!'; \
+                exit 1; \
+        }; \
+        \
+        New-Item -ItemType Directory -Path C:\temp | Out-Null;
+
+RUN Write-Host 'Installing using MSI ...'; \
+        Start-Process -FilePath "msiexec.exe" -ArgumentList '/i', 'openjdk.msi', '/L*V', 'C:\temp\OpenJDK.log', \
+        '/quiet', 'ADDLOCAL=FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome' -Wait -Passthru; \
+        Write-Host 'Removing ...'; \
+        Remove-Item openjdk.msi -Force;
+
+RUN Write-Host 'Verifying install ...'; \
+        Write-Host '  java -version'; java -version; \
+        Write-Host '  javac -version'; javac -version; \
+        Write-Host '  JAVA_HOME'; Test-Path $env:JAVA_HOME;
 
 # https://docs.oracle.com/javase/10/tools/jshell.htm
 # https://en.wikipedia.org/wiki/JShell

--- a/8/jdk/windows/windowsservercore-1803/Dockerfile
+++ b/8/jdk/windows/windowsservercore-1803/Dockerfile
@@ -3,42 +3,29 @@ FROM mcr.microsoft.com/windows/servercore:1803
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_HOME C:\\ojdkbuild
-RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
-	Write-Host ('Updating PATH: {0}' -f $newPath); \
-# Nano Server does not have "[Environment]::SetEnvironmentVariable()"
-	setx /M PATH $newPath;
+# https://adoptopenjdk.net/
+ENV JAVA_VERSION 8.0.212+3
+ENV JAVA_URL https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03/OpenJDK8U-jdk_x64_windows_hotspot_8u212b03.msi
+ENV JAVA_SHA256 86cf932a04dff28e19a5f715cbb8f2c34ce78fa12d30578bcaf7fb46f88a3acb
 
-# https://github.com/ojdkbuild/ojdkbuild/releases
-ENV JAVA_VERSION 8u212
-ENV JAVA_OJDKBUILD_VERSION 1.8.0.212-1
-ENV JAVA_OJDKBUILD_ZIP java-1.8.0-openjdk-1.8.0.212-1.b04.ojdkbuild.windows.x86_64.zip
-ENV JAVA_OJDKBUILD_SHA256 a40d7ab150bb2c2b3ad19e388942c4fe47b92a89dd49c468e09ce9d8bc631934
+RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \
+                Write-Host 'FAILED!'; \
+                exit 1; \
+        }; \
+        \
+        New-Item -ItemType Directory -Path C:\temp | Out-Null;
 
-RUN $url = ('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/{1}' -f $env:JAVA_OJDKBUILD_VERSION, $env:JAVA_OJDKBUILD_ZIP); \
-	Write-Host ('Downloading {0} ...' -f $url); \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -Uri $url -OutFile 'ojdkbuild.zip'; \
-	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_OJDKBUILD_SHA256); \
-	if ((Get-FileHash ojdkbuild.zip -Algorithm sha256).Hash -ne $env:JAVA_OJDKBUILD_SHA256) { \
-		Write-Host 'FAILED!'; \
-		exit 1; \
-	}; \
-	\
-	Write-Host 'Expanding ...'; \
-	Expand-Archive ojdkbuild.zip -DestinationPath C:\; \
-	\
-	Write-Host 'Renaming ...'; \
-	Move-Item \
-		-Path ('C:\{0}' -f ($env:JAVA_OJDKBUILD_ZIP -Replace '.zip$', '')) \
-		-Destination $env:JAVA_HOME \
-	; \
-	\
-	Write-Host 'Verifying install ...'; \
-	Write-Host '  java -version'; java -version; \
-	Write-Host '  javac -version'; javac -version; \
-	\
-	Write-Host 'Removing ...'; \
-	Remove-Item ojdkbuild.zip -Force; \
-	\
-	Write-Host 'Complete.';
+RUN Write-Host 'Installing using MSI ...'; \
+        Start-Process -FilePath "msiexec.exe" -ArgumentList '/i', 'openjdk.msi', '/L*V', 'C:\temp\OpenJDK.log', \
+        '/quiet', 'ADDLOCAL=FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome' -Wait -Passthru; \
+        Write-Host 'Removing ...'; \
+        Remove-Item openjdk.msi -Force;
+
+RUN Write-Host 'Verifying install ...'; \
+        Write-Host '  java -version'; java -version; \
+        Write-Host '  javac -version'; javac -version; \
+        Write-Host '  JAVA_HOME'; Test-Path $env:JAVA_HOME;

--- a/8/jdk/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/8/jdk/windows/windowsservercore-ltsc2016/Dockerfile
@@ -3,42 +3,29 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_HOME C:\\ojdkbuild
-RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
-	Write-Host ('Updating PATH: {0}' -f $newPath); \
-# Nano Server does not have "[Environment]::SetEnvironmentVariable()"
-	setx /M PATH $newPath;
+# https://adoptopenjdk.net/
+ENV JAVA_VERSION 8.0.212+3
+ENV JAVA_URL https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03/OpenJDK8U-jdk_x64_windows_hotspot_8u212b03.msi
+ENV JAVA_SHA256 86cf932a04dff28e19a5f715cbb8f2c34ce78fa12d30578bcaf7fb46f88a3acb
 
-# https://github.com/ojdkbuild/ojdkbuild/releases
-ENV JAVA_VERSION 8u212
-ENV JAVA_OJDKBUILD_VERSION 1.8.0.212-1
-ENV JAVA_OJDKBUILD_ZIP java-1.8.0-openjdk-1.8.0.212-1.b04.ojdkbuild.windows.x86_64.zip
-ENV JAVA_OJDKBUILD_SHA256 a40d7ab150bb2c2b3ad19e388942c4fe47b92a89dd49c468e09ce9d8bc631934
+RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \
+                Write-Host 'FAILED!'; \
+                exit 1; \
+        }; \
+        \
+        New-Item -ItemType Directory -Path C:\temp | Out-Null;
 
-RUN $url = ('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/{1}' -f $env:JAVA_OJDKBUILD_VERSION, $env:JAVA_OJDKBUILD_ZIP); \
-	Write-Host ('Downloading {0} ...' -f $url); \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -Uri $url -OutFile 'ojdkbuild.zip'; \
-	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_OJDKBUILD_SHA256); \
-	if ((Get-FileHash ojdkbuild.zip -Algorithm sha256).Hash -ne $env:JAVA_OJDKBUILD_SHA256) { \
-		Write-Host 'FAILED!'; \
-		exit 1; \
-	}; \
-	\
-	Write-Host 'Expanding ...'; \
-	Expand-Archive ojdkbuild.zip -DestinationPath C:\; \
-	\
-	Write-Host 'Renaming ...'; \
-	Move-Item \
-		-Path ('C:\{0}' -f ($env:JAVA_OJDKBUILD_ZIP -Replace '.zip$', '')) \
-		-Destination $env:JAVA_HOME \
-	; \
-	\
-	Write-Host 'Verifying install ...'; \
-	Write-Host '  java --version'; java --version; \
-	Write-Host '  javac --version'; javac --version; \
-	\
-	Write-Host 'Removing ...'; \
-	Remove-Item ojdkbuild.zip -Force; \
-	\
-	Write-Host 'Complete.';
+RUN Write-Host 'Installing using MSI ...'; \
+        Start-Process -FilePath "msiexec.exe" -ArgumentList '/i', 'openjdk.msi', '/L*V', 'C:\temp\OpenJDK.log', \
+        '/quiet', 'ADDLOCAL=FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome' -Wait -Passthru; \
+        Write-Host 'Removing ...'; \
+        Remove-Item openjdk.msi -Force;
+
+RUN Write-Host 'Verifying install ...'; \
+        Write-Host '  java -version'; java -version; \
+        Write-Host '  javac -version'; javac -version; \
+        Write-Host '  JAVA_HOME'; Test-Path $env:JAVA_HOME;

--- a/Dockerfile-windows-msi.template
+++ b/Dockerfile-windows-msi.template
@@ -1,12 +1,12 @@
-FROM mcr.microsoft.com/windows/servercore:1809
+FROM placeholder
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # https://adoptopenjdk.net/
-ENV JAVA_VERSION 8.0.212+3
-ENV JAVA_URL https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03/OpenJDK8U-jdk_x64_windows_hotspot_8u212b03.msi
-ENV JAVA_SHA256 86cf932a04dff28e19a5f715cbb8f2c34ce78fa12d30578bcaf7fb46f88a3acb
+ENV JAVA_VERSION placeholder
+ENV JAVA_URL placeholder
+ENV JAVA_SHA256 placeholder
 
 RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \


### PR DESCRIPTION
Switch to using AdoptOpenJDK MSI's for windows dockerfiles.

I wasn't sure if I needed the following block:

```powershell
# enable TLS 1.2 (Nano Server doesn't support using "[Net.ServicePointManager]::SecurityProtocol")
# https://docs.microsoft.com/en-us/system-center/vmm/install-tls?view=sc-vmm-1801
# https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs#enable-tls-12
RUN Write-Host 'Enabling TLS 1.2 (https://githubengineering.com/crypto-removal-notice/) ...'; \
	$tls12RegBase = 'HKLM:\\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2'; \
	if (Test-Path $tls12RegBase) { throw ('"{0}" already exists!' -f $tls12RegBase) }; \
	New-Item -Path ('{0}/Client' -f $tls12RegBase) -Force; \
	New-Item -Path ('{0}/Server' -f $tls12RegBase) -Force; \
	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force; \
	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force
```