### PR TITLE
Default to a sensible encoding

### DIFF
--- a/12/jdk/oracle/Dockerfile
+++ b/12/jdk/oracle/Dockerfile
@@ -12,8 +12,7 @@ RUN set -eux; \
 	rm -rf /var/cache/yum
 
 # Default to UTF-8 file.encoding
-#ENV LANG C.UTF-8
-# TODO oraclelinux doesn't have C.UTF-8 by default??
+ENV LANG=en_US.UTF-8
 
 ENV JAVA_HOME /usr/java/openjdk-12
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/12/jdk/oracle/Dockerfile
+++ b/12/jdk/oracle/Dockerfile
@@ -12,7 +12,7 @@ RUN set -eux; \
 	rm -rf /var/cache/yum
 
 # Default to UTF-8 file.encoding
-ENV LANG=en_US.UTF-8
+ENV LANG en_US.UTF-8
 
 ENV JAVA_HOME /usr/java/openjdk-12
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/13/jdk/oracle/Dockerfile
+++ b/13/jdk/oracle/Dockerfile
@@ -12,8 +12,7 @@ RUN set -eux; \
 	rm -rf /var/cache/yum
 
 # Default to UTF-8 file.encoding
-#ENV LANG C.UTF-8
-# TODO oraclelinux doesn't have C.UTF-8 by default??
+ENV LANG en_US.UTF-8
 
 ENV JAVA_HOME /usr/java/openjdk-13
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/Dockerfile-oracle.template
+++ b/Dockerfile-oracle.template
@@ -12,8 +12,7 @@ RUN set -eux; \
 	rm -rf /var/cache/yum
 
 # Default to UTF-8 file.encoding
-#ENV LANG C.UTF-8
-# TODO oraclelinux doesn't have C.UTF-8 by default??
+ENV LANG en_US.UTF-8
 
 ENV JAVA_HOME placeholder
 ENV PATH $JAVA_HOME/bin:$PATH


### PR DESCRIPTION
Will work with files that contain unicode characters, closest to Debian's`C.UTF-8` on distros where the latter _tends_ to be omitted out of the box (Arch, Fedora, CentOS, RedHat, Oracle, etc.). 

Note: The default (if `LANG` is unspecified) is just `en_US` (well, actually depending on the installation locale), which is ISO 8859-1 — essentially ASCII with an 8th bit. Given Java's native support for unicode, leaving the default `en_US` is less than ideal.