### PR TITLE
Add binutils for objcopy to fix `jlink --strip-debug` on oracle 13+

### DIFF
--- a/13/jdk/oracle/Dockerfile
+++ b/13/jdk/oracle/Dockerfile
@@ -5,6 +5,9 @@ RUN set -eux; \
 		gzip \
 		tar \
 		\
+# jlink --strip-debug on 13+ needs objcopy: https://github.com/docker-library/openjdk/issues/351
+# Error: java.io.IOException: Cannot run program "objcopy": error=2, No such file or directory
+		binutils \
 # java.lang.UnsatisfiedLinkError: /usr/java/openjdk-12/lib/libfontmanager.so: libfreetype.so.6: cannot open shared object file: No such file or directory
 # https://github.com/docker-library/openjdk/pull/235#issuecomment-424466077
 		freetype fontconfig \

--- a/14/jdk/oracle/Dockerfile
+++ b/14/jdk/oracle/Dockerfile
@@ -5,6 +5,9 @@ RUN set -eux; \
 		gzip \
 		tar \
 		\
+# jlink --strip-debug on 13+ needs objcopy: https://github.com/docker-library/openjdk/issues/351
+# Error: java.io.IOException: Cannot run program "objcopy": error=2, No such file or directory
+		binutils \
 # java.lang.UnsatisfiedLinkError: /usr/java/openjdk-12/lib/libfontmanager.so: libfreetype.so.6: cannot open shared object file: No such file or directory
 # https://github.com/docker-library/openjdk/pull/235#issuecomment-424466077
 		freetype fontconfig \

--- a/Dockerfile-oracle-oracle.template
+++ b/Dockerfile-oracle-oracle.template
@@ -5,6 +5,9 @@ RUN set -eux; \
 		gzip \
 		tar \
 		\
+# jlink --strip-debug on 13+ needs objcopy: https://github.com/docker-library/openjdk/issues/351
+# Error: java.io.IOException: Cannot run program "objcopy": error=2, No such file or directory
+		binutils \
 # java.lang.UnsatisfiedLinkError: /usr/java/openjdk-12/lib/libfontmanager.so: libfreetype.so.6: cannot open shared object file: No such file or directory
 # https://github.com/docker-library/openjdk/pull/235#issuecomment-424466077
 		freetype fontconfig \

--- a/update.sh
+++ b/update.sh
@@ -215,6 +215,10 @@ for javaVersion in "${versions[@]}"; do
 						-e 's!^(ENV JAVA_URL) .*!\1 '"$downloadUrl"'!' \
 						-e 's!^(ENV JAVA_SHA256) .*!\1 '"$downloadSha256"'!' \
 						Dockerfile-oracle-oracle.template > "$dir/oracle/Dockerfile"
+					if [ "$javaVersion" = '12' ]; then
+						# https://github.com/docker-library/openjdk/issues/351
+						sed -ri '/objcopy|binutils/d' "$dir/oracle/Dockerfile"
+					fi
 				fi
 
 				if [ -d "$dir/windows" ]; then


### PR DESCRIPTION
Fixes #351.