### PR TITLE
Add initial Oracle arm64v8 support

### DIFF
--- a/14/jdk/Dockerfile
+++ b/14/jdk/Dockerfile
@@ -32,13 +32,23 @@ RUN { echo '#/bin/sh'; echo 'echo "$JAVA_HOME"'; } > /usr/local/bin/docker-java-
 # https://jdk.java.net/
 # > Java Development Kit builds, from Oracle
 ENV JAVA_VERSION 14.0.1
-ENV JAVA_URL https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_linux-x64_bin.tar.gz
-ENV JAVA_SHA256 22ce248e0bd69f23028625bede9d1b3080935b68d011eaaf9e241f84d6b9c4cc
 
 RUN set -eux; \
 	\
-	wget -O openjdk.tgz "$JAVA_URL"; \
-	echo "$JAVA_SHA256 */openjdk.tgz" | sha256sum -c -; \
+	arch="$(dpkg --print-architecture)"; \
+# this "case" statement is generated via "update.sh"
+	case "$arch" in \
+# amd64
+		amd64 | i386:x86-64) \
+			downloadUrl=https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_linux-x64_bin.tar.gz; \
+			downloadSha256=22ce248e0bd69f23028625bede9d1b3080935b68d011eaaf9e241f84d6b9c4cc; \
+			;; \
+# fallback
+		*) echo >&2 "error: unsupported architecture: '$arch'"; exit 1 ;; \
+	esac; \
+	\
+	wget -O openjdk.tgz "$downloadUrl"; \
+	echo "$downloadSha256 */openjdk.tgz" | sha256sum -c -; \
 	\
 	mkdir -p "$JAVA_HOME"; \
 	tar --extract \

--- a/14/jdk/oracle/Dockerfile
+++ b/14/jdk/oracle/Dockerfile
@@ -23,13 +23,25 @@ ENV PATH $JAVA_HOME/bin:$PATH
 # https://jdk.java.net/
 # > Java Development Kit builds, from Oracle
 ENV JAVA_VERSION 14.0.1
-ENV JAVA_URL https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_linux-x64_bin.tar.gz
-ENV JAVA_SHA256 22ce248e0bd69f23028625bede9d1b3080935b68d011eaaf9e241f84d6b9c4cc
 
 RUN set -eux; \
 	\
-	curl -fL -o /openjdk.tgz "$JAVA_URL"; \
-	echo "$JAVA_SHA256 */openjdk.tgz" | sha256sum -c -; \
+	objdump="$(command -v objdump)"; \
+	arch="$(objdump --file-headers "$objdump" | awk -F '[:,]+[[:space:]]+' '$1 == "architecture" { print $2 }')"; \
+# this "case" statement is generated via "update.sh"
+	case "$arch" in \
+# amd64
+		amd64 | i386:x86-64) \
+			downloadUrl=https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_linux-x64_bin.tar.gz; \
+			downloadSha256=22ce248e0bd69f23028625bede9d1b3080935b68d011eaaf9e241f84d6b9c4cc; \
+			;; \
+# fallback
+		*) echo >&2 "error: unsupported architecture: '$arch'"; exit 1 ;; \
+	esac; \
+	\
+	curl -fL -o /openjdk.tgz "$downloadUrl"; \
+	echo "$downloadSha256 */openjdk.tgz" | sha256sum -c -; \
+	\
 	mkdir -p "$JAVA_HOME"; \
 	tar --extract --file /openjdk.tgz --directory "$JAVA_HOME" --strip-components 1; \
 	rm /openjdk.tgz; \

--- a/14/jdk/slim/Dockerfile
+++ b/14/jdk/slim/Dockerfile
@@ -20,8 +20,6 @@ RUN { echo '#/bin/sh'; echo 'echo "$JAVA_HOME"'; } > /usr/local/bin/docker-java-
 # https://jdk.java.net/
 # > Java Development Kit builds, from Oracle
 ENV JAVA_VERSION 14.0.1
-ENV JAVA_URL https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_linux-x64_bin.tar.gz
-ENV JAVA_SHA256 22ce248e0bd69f23028625bede9d1b3080935b68d011eaaf9e241f84d6b9c4cc
 
 RUN set -eux; \
 	\
@@ -32,8 +30,20 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
-	wget -O openjdk.tgz "$JAVA_URL"; \
-	echo "$JAVA_SHA256 */openjdk.tgz" | sha256sum -c -; \
+	arch="$(dpkg --print-architecture)"; \
+# this "case" statement is generated via "update.sh"
+	case "$arch" in \
+# amd64
+		amd64 | i386:x86-64) \
+			downloadUrl=https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_linux-x64_bin.tar.gz; \
+			downloadSha256=22ce248e0bd69f23028625bede9d1b3080935b68d011eaaf9e241f84d6b9c4cc; \
+			;; \
+# fallback
+		*) echo >&2 "error: unsupported architecture: '$arch'"; exit 1 ;; \
+	esac; \
+	\
+	wget -O openjdk.tgz "$downloadUrl"; \
+	echo "$downloadSha256 */openjdk.tgz" | sha256sum -c -; \
 	\
 	mkdir -p "$JAVA_HOME"; \
 	tar --extract \

--- a/15/jdk/Dockerfile
+++ b/15/jdk/Dockerfile
@@ -32,13 +32,28 @@ RUN { echo '#/bin/sh'; echo 'echo "$JAVA_HOME"'; } > /usr/local/bin/docker-java-
 # https://jdk.java.net/
 # > Java Development Kit builds, from Oracle
 ENV JAVA_VERSION 15-ea+23
-ENV JAVA_URL https://download.java.net/java/early_access/jdk15/23/GPL/openjdk-15-ea+23_linux-x64_bin.tar.gz
-ENV JAVA_SHA256 0a3a3f2bb3005d848f9a579c46c1cb581b46d6805faf673a7c1b5a2f158cd1b0
 
 RUN set -eux; \
 	\
-	wget -O openjdk.tgz "$JAVA_URL"; \
-	echo "$JAVA_SHA256 */openjdk.tgz" | sha256sum -c -; \
+	arch="$(dpkg --print-architecture)"; \
+# this "case" statement is generated via "update.sh"
+	case "$arch" in \
+# arm64v8
+		arm64 | aarch64) \
+			downloadUrl=https://download.java.net/java/early_access/jdk15/23/GPL/openjdk-15-ea+23_linux-aarch64_bin.tar.gz; \
+			downloadSha256=c9817b2efa619dcde0d4a5fa9dd1d6bcbe5bdf05fee152e9a06387544c4e5c90; \
+			;; \
+# amd64
+		amd64 | i386:x86-64) \
+			downloadUrl=https://download.java.net/java/early_access/jdk15/23/GPL/openjdk-15-ea+23_linux-x64_bin.tar.gz; \
+			downloadSha256=0a3a3f2bb3005d848f9a579c46c1cb581b46d6805faf673a7c1b5a2f158cd1b0; \
+			;; \
+# fallback
+		*) echo >&2 "error: unsupported architecture: '$arch'"; exit 1 ;; \
+	esac; \
+	\
+	wget -O openjdk.tgz "$downloadUrl"; \
+	echo "$downloadSha256 */openjdk.tgz" | sha256sum -c -; \
 	\
 	mkdir -p "$JAVA_HOME"; \
 	tar --extract \

--- a/15/jdk/alpine/Dockerfile
+++ b/15/jdk/alpine/Dockerfile
@@ -14,6 +14,7 @@ RUN set -eux; \
 	\
 	wget -O /openjdk.tgz "$JAVA_URL"; \
 	echo "$JAVA_SHA256 */openjdk.tgz" | sha256sum -c -; \
+	\
 	mkdir -p "$JAVA_HOME"; \
 	tar --extract --file /openjdk.tgz --directory "$JAVA_HOME" --strip-components 1; \
 	rm /openjdk.tgz; \

--- a/15/jdk/oracle/Dockerfile
+++ b/15/jdk/oracle/Dockerfile
@@ -23,13 +23,30 @@ ENV PATH $JAVA_HOME/bin:$PATH
 # https://jdk.java.net/
 # > Java Development Kit builds, from Oracle
 ENV JAVA_VERSION 15-ea+23
-ENV JAVA_URL https://download.java.net/java/early_access/jdk15/23/GPL/openjdk-15-ea+23_linux-x64_bin.tar.gz
-ENV JAVA_SHA256 0a3a3f2bb3005d848f9a579c46c1cb581b46d6805faf673a7c1b5a2f158cd1b0
 
 RUN set -eux; \
 	\
-	curl -fL -o /openjdk.tgz "$JAVA_URL"; \
-	echo "$JAVA_SHA256 */openjdk.tgz" | sha256sum -c -; \
+	objdump="$(command -v objdump)"; \
+	arch="$(objdump --file-headers "$objdump" | awk -F '[:,]+[[:space:]]+' '$1 == "architecture" { print $2 }')"; \
+# this "case" statement is generated via "update.sh"
+	case "$arch" in \
+# arm64v8
+		arm64 | aarch64) \
+			downloadUrl=https://download.java.net/java/early_access/jdk15/23/GPL/openjdk-15-ea+23_linux-aarch64_bin.tar.gz; \
+			downloadSha256=c9817b2efa619dcde0d4a5fa9dd1d6bcbe5bdf05fee152e9a06387544c4e5c90; \
+			;; \
+# amd64
+		amd64 | i386:x86-64) \
+			downloadUrl=https://download.java.net/java/early_access/jdk15/23/GPL/openjdk-15-ea+23_linux-x64_bin.tar.gz; \
+			downloadSha256=0a3a3f2bb3005d848f9a579c46c1cb581b46d6805faf673a7c1b5a2f158cd1b0; \
+			;; \
+# fallback
+		*) echo >&2 "error: unsupported architecture: '$arch'"; exit 1 ;; \
+	esac; \
+	\
+	curl -fL -o /openjdk.tgz "$downloadUrl"; \
+	echo "$downloadSha256 */openjdk.tgz" | sha256sum -c -; \
+	\
 	mkdir -p "$JAVA_HOME"; \
 	tar --extract --file /openjdk.tgz --directory "$JAVA_HOME" --strip-components 1; \
 	rm /openjdk.tgz; \

--- a/15/jdk/slim/Dockerfile
+++ b/15/jdk/slim/Dockerfile
@@ -20,8 +20,6 @@ RUN { echo '#/bin/sh'; echo 'echo "$JAVA_HOME"'; } > /usr/local/bin/docker-java-
 # https://jdk.java.net/
 # > Java Development Kit builds, from Oracle
 ENV JAVA_VERSION 15-ea+23
-ENV JAVA_URL https://download.java.net/java/early_access/jdk15/23/GPL/openjdk-15-ea+23_linux-x64_bin.tar.gz
-ENV JAVA_SHA256 0a3a3f2bb3005d848f9a579c46c1cb581b46d6805faf673a7c1b5a2f158cd1b0
 
 RUN set -eux; \
 	\
@@ -32,8 +30,25 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
-	wget -O openjdk.tgz "$JAVA_URL"; \
-	echo "$JAVA_SHA256 */openjdk.tgz" | sha256sum -c -; \
+	arch="$(dpkg --print-architecture)"; \
+# this "case" statement is generated via "update.sh"
+	case "$arch" in \
+# arm64v8
+		arm64 | aarch64) \
+			downloadUrl=https://download.java.net/java/early_access/jdk15/23/GPL/openjdk-15-ea+23_linux-aarch64_bin.tar.gz; \
+			downloadSha256=c9817b2efa619dcde0d4a5fa9dd1d6bcbe5bdf05fee152e9a06387544c4e5c90; \
+			;; \
+# amd64
+		amd64 | i386:x86-64) \
+			downloadUrl=https://download.java.net/java/early_access/jdk15/23/GPL/openjdk-15-ea+23_linux-x64_bin.tar.gz; \
+			downloadSha256=0a3a3f2bb3005d848f9a579c46c1cb581b46d6805faf673a7c1b5a2f158cd1b0; \
+			;; \
+# fallback
+		*) echo >&2 "error: unsupported architecture: '$arch'"; exit 1 ;; \
+	esac; \
+	\
+	wget -O openjdk.tgz "$downloadUrl"; \
+	echo "$downloadSha256 */openjdk.tgz" | sha256sum -c -; \
 	\
 	mkdir -p "$JAVA_HOME"; \
 	tar --extract \

--- a/Dockerfile-oracle-alpine.template
+++ b/Dockerfile-oracle-alpine.template
@@ -14,6 +14,7 @@ RUN set -eux; \
 	\
 	wget -O /openjdk.tgz "$JAVA_URL"; \
 	echo "$JAVA_SHA256 */openjdk.tgz" | sha256sum -c -; \
+	\
 	mkdir -p "$JAVA_HOME"; \
 	tar --extract --file /openjdk.tgz --directory "$JAVA_HOME" --strip-components 1; \
 	rm /openjdk.tgz; \

--- a/Dockerfile-oracle-debian.template
+++ b/Dockerfile-oracle-debian.template
@@ -32,13 +32,15 @@ RUN { echo '#/bin/sh'; echo 'echo "$JAVA_HOME"'; } > /usr/local/bin/docker-java-
 # https://jdk.java.net/
 # > Java Development Kit builds, from Oracle
 ENV JAVA_VERSION placeholder
-ENV JAVA_URL placeholder
-ENV JAVA_SHA256 placeholder
 
 RUN set -eux; \
 	\
-	wget -O openjdk.tgz "$JAVA_URL"; \
-	echo "$JAVA_SHA256 */openjdk.tgz" | sha256sum -c -; \
+	arch="$(dpkg --print-architecture)"; \
+# this "case" statement is generated via "update.sh"
+	%%ARCH-CASE%%; \
+	\
+	wget -O openjdk.tgz "$downloadUrl"; \
+	echo "$downloadSha256 */openjdk.tgz" | sha256sum -c -; \
 	\
 	mkdir -p "$JAVA_HOME"; \
 	tar --extract \

--- a/Dockerfile-oracle-oracle.template
+++ b/Dockerfile-oracle-oracle.template
@@ -23,13 +23,17 @@ ENV PATH $JAVA_HOME/bin:$PATH
 # https://jdk.java.net/
 # > Java Development Kit builds, from Oracle
 ENV JAVA_VERSION placeholder
-ENV JAVA_URL placeholder
-ENV JAVA_SHA256 placeholder
 
 RUN set -eux; \
 	\
-	curl -fL -o /openjdk.tgz "$JAVA_URL"; \
-	echo "$JAVA_SHA256 */openjdk.tgz" | sha256sum -c -; \
+	objdump="$(command -v objdump)"; \
+	arch="$(objdump --file-headers "$objdump" | awk -F '[:,]+[[:space:]]+' '$1 == "architecture" { print $2 }')"; \
+# this "case" statement is generated via "update.sh"
+	%%ARCH-CASE%%; \
+	\
+	curl -fL -o /openjdk.tgz "$downloadUrl"; \
+	echo "$downloadSha256 */openjdk.tgz" | sha256sum -c -; \
+	\
 	mkdir -p "$JAVA_HOME"; \
 	tar --extract --file /openjdk.tgz --directory "$JAVA_HOME" --strip-components 1; \
 	rm /openjdk.tgz; \

--- a/Dockerfile-oracle-slim.template
+++ b/Dockerfile-oracle-slim.template
@@ -20,8 +20,6 @@ RUN { echo '#/bin/sh'; echo 'echo "$JAVA_HOME"'; } > /usr/local/bin/docker-java-
 # https://jdk.java.net/
 # > Java Development Kit builds, from Oracle
 ENV JAVA_VERSION placeholder
-ENV JAVA_URL placeholder
-ENV JAVA_SHA256 placeholder
 
 RUN set -eux; \
 	\
@@ -32,8 +30,12 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
-	wget -O openjdk.tgz "$JAVA_URL"; \
-	echo "$JAVA_SHA256 */openjdk.tgz" | sha256sum -c -; \
+	arch="$(dpkg --print-architecture)"; \
+# this "case" statement is generated via "update.sh"
+	%%ARCH-CASE%%; \
+	\
+	wget -O openjdk.tgz "$downloadUrl"; \
+	echo "$downloadSha256 */openjdk.tgz" | sha256sum -c -; \
 	\
 	mkdir -p "$JAVA_HOME"; \
 	tar --extract \


### PR DESCRIPTION
Oracle has added "aarch64" builds to https://jdk.java.net/15/ which I'm hoping will last past the EA period!