### PR TITLE
Add "java-cacerts" to Alpine-based image to maintain "$JAVA_HOME/lib/security/cacerts" for us

### DIFF
--- a/15/jdk/alpine/Dockerfile
+++ b/15/jdk/alpine/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.11
 
+RUN apk add --no-cache java-cacerts
+
 ENV JAVA_HOME /opt/openjdk-15
 ENV PATH $JAVA_HOME/bin:$PATH
 
@@ -22,6 +24,10 @@ RUN set -eux; \
 # https://github.com/docker-library/openjdk/issues/212#issuecomment-420979840
 # https://openjdk.java.net/jeps/341
 	java -Xshare:dump; \
+	\
+# see "java-cacerts" package installed above (which maintains "/etc/ssl/certs/java/cacerts" for us)
+	rm -rf "$JAVA_HOME/lib/security/cacerts"; \
+	ln -sT /etc/ssl/certs/java/cacerts "$JAVA_HOME/lib/security/cacerts"; \
 	\
 # basic smoke test
 	java --version; \

--- a/Dockerfile-oracle-alpine.template
+++ b/Dockerfile-oracle-alpine.template
@@ -1,5 +1,7 @@
 FROM alpine:3.11
 
+RUN apk add --no-cache java-cacerts
+
 ENV JAVA_HOME placeholder
 ENV PATH $JAVA_HOME/bin:$PATH
 
@@ -22,6 +24,10 @@ RUN set -eux; \
 # https://github.com/docker-library/openjdk/issues/212#issuecomment-420979840
 # https://openjdk.java.net/jeps/341
 	java -Xshare:dump; \
+	\
+# see "java-cacerts" package installed above (which maintains "/etc/ssl/certs/java/cacerts" for us)
+	rm -rf "$JAVA_HOME/lib/security/cacerts"; \
+	ln -sT /etc/ssl/certs/java/cacerts "$JAVA_HOME/lib/security/cacerts"; \
 	\
 # basic smoke test
 	java --version; \


### PR DESCRIPTION
Refs #416

This `java-cacerts` package is what the `openjdk*` packages in Alpine itself use to maintain this `cacerts` bundle (and is what inspired the solution we have in Debian-based images :smile:).