### PR TITLE
Update to Oracle Linux 8

### DIFF
--- a/14/jdk/oraclelinux8/Dockerfile
+++ b/14/jdk/oraclelinux8/Dockerfile
@@ -1,4 +1,4 @@
-FROM oraclelinux:placeholder-slim
+FROM oraclelinux:8-slim
 
 RUN set -eux; \
 	microdnf install \
@@ -17,21 +17,29 @@ RUN set -eux; \
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
-ENV JAVA_HOME placeholder
+ENV JAVA_HOME /usr/java/openjdk-14
 ENV PATH $JAVA_HOME/bin:$PATH
 
 # https://jdk.java.net/
 # >
 # > Java Development Kit builds, from Oracle
 # >
-ENV JAVA_VERSION placeholder
+ENV JAVA_VERSION 14.0.2
 
 RUN set -eux; \
 	\
 	objdump="$(command -v objdump)"; \
 	arch="$(objdump --file-headers "$objdump" | awk -F '[:,]+[[:space:]]+' '$1 == "architecture" { print $2 }')"; \
 # this "case" statement is generated via "update.sh"
-	%%ARCH-CASE%%; \
+	case "$arch" in \
+# amd64
+		amd64 | i386:x86-64) \
+			downloadUrl=https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_linux-x64_bin.tar.gz; \
+			downloadSha256=91310200f072045dc6cef2c8c23e7e6387b37c46e9de49623ce0fa461a24623d; \
+			;; \
+# fallback
+		*) echo >&2 "error: unsupported architecture: '$arch'"; exit 1 ;; \
+	esac; \
 	\
 	curl -fL -o openjdk.tgz "$downloadUrl"; \
 	echo "$downloadSha256 *openjdk.tgz" | sha256sum --strict --check -; \

--- a/15/jdk/oraclelinux8/Dockerfile
+++ b/15/jdk/oraclelinux8/Dockerfile
@@ -1,4 +1,4 @@
-FROM oraclelinux:placeholder-slim
+FROM oraclelinux:8-slim
 
 RUN set -eux; \
 	microdnf install \
@@ -17,21 +17,34 @@ RUN set -eux; \
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
-ENV JAVA_HOME placeholder
+ENV JAVA_HOME /usr/java/openjdk-15
 ENV PATH $JAVA_HOME/bin:$PATH
 
 # https://jdk.java.net/
 # >
 # > Java Development Kit builds, from Oracle
 # >
-ENV JAVA_VERSION placeholder
+ENV JAVA_VERSION 15
 
 RUN set -eux; \
 	\
 	objdump="$(command -v objdump)"; \
 	arch="$(objdump --file-headers "$objdump" | awk -F '[:,]+[[:space:]]+' '$1 == "architecture" { print $2 }')"; \
 # this "case" statement is generated via "update.sh"
-	%%ARCH-CASE%%; \
+	case "$arch" in \
+# arm64v8
+		arm64 | aarch64) \
+			downloadUrl=https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_linux-aarch64_bin.tar.gz; \
+			downloadSha256=01e7e07dd8a67a65b32fdcaff75ba3f21cd9cfc749287e7c9b1c6037f96a3537; \
+			;; \
+# amd64
+		amd64 | i386:x86-64) \
+			downloadUrl=https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_linux-x64_bin.tar.gz; \
+			downloadSha256=bb67cadee687d7b486583d03c9850342afea4593be4f436044d785fba9508fb7; \
+			;; \
+# fallback
+		*) echo >&2 "error: unsupported architecture: '$arch'"; exit 1 ;; \
+	esac; \
 	\
 	curl -fL -o openjdk.tgz "$downloadUrl"; \
 	echo "$downloadSha256 *openjdk.tgz" | sha256sum --strict --check -; \

--- a/16/jdk/oraclelinux8/Dockerfile
+++ b/16/jdk/oraclelinux8/Dockerfile
@@ -1,4 +1,4 @@
-FROM oraclelinux:placeholder-slim
+FROM oraclelinux:8-slim
 
 RUN set -eux; \
 	microdnf install \
@@ -17,21 +17,34 @@ RUN set -eux; \
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
-ENV JAVA_HOME placeholder
+ENV JAVA_HOME /usr/java/openjdk-16
 ENV PATH $JAVA_HOME/bin:$PATH
 
 # https://jdk.java.net/
 # >
 # > Java Development Kit builds, from Oracle
 # >
-ENV JAVA_VERSION placeholder
+ENV JAVA_VERSION 16-ea+12
 
 RUN set -eux; \
 	\
 	objdump="$(command -v objdump)"; \
 	arch="$(objdump --file-headers "$objdump" | awk -F '[:,]+[[:space:]]+' '$1 == "architecture" { print $2 }')"; \
 # this "case" statement is generated via "update.sh"
-	%%ARCH-CASE%%; \
+	case "$arch" in \
+# arm64v8
+		arm64 | aarch64) \
+			downloadUrl=https://download.java.net/java/early_access/jdk16/12/GPL/openjdk-16-ea+12_linux-aarch64_bin.tar.gz; \
+			downloadSha256=354114377e3c9d332c70326ddaf7b3f5014b9f025c80012bd96a2bd0d663b6b3; \
+			;; \
+# amd64
+		amd64 | i386:x86-64) \
+			downloadUrl=https://download.java.net/java/early_access/jdk16/12/GPL/openjdk-16-ea+12_linux-x64_bin.tar.gz; \
+			downloadSha256=6e27c3227840de2edfa5a8325294868b6580bd00ca1f8597eb6189c5f67a31e1; \
+			;; \
+# fallback
+		*) echo >&2 "error: unsupported architecture: '$arch'"; exit 1 ;; \
+	esac; \
 	\
 	curl -fL -o openjdk.tgz "$downloadUrl"; \
 	echo "$downloadSha256 *openjdk.tgz" | sha256sum --strict --check -; \

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -8,7 +8,7 @@ declare -A aliases=(
 defaultType='jdk'
 defaultAlpine='3.12'
 defaultDebian='buster'
-defaultOracle='7'
+defaultOracle='8'
 
 image="${1:-openjdk}"
 
@@ -144,7 +144,7 @@ aliases() {
 for javaVersion in "${versions[@]}"; do
 	for javaType in jdk jre; do
 		for v in \
-			oraclelinux7 \
+			oraclelinux{8,7} \
 			{,slim-}buster \
 			alpine3.12 \
 			windows/windowsservercore-{1809,ltsc2016} \

--- a/update.sh
+++ b/update.sh
@@ -280,7 +280,7 @@ for javaVersion in "${versions[@]}"; do
 		alpineArchCase="${archCasePrefix}${alpineArchCase}${archCaseSuffix}"
 
 		for variant in \
-			oraclelinux7 \
+			oraclelinux{8,7} \
 			{,slim-}buster \
 			alpine3.12 \
 			windows/windowsservercore-{1809,ltsc2016} \
@@ -303,10 +303,18 @@ for javaVersion in "${versions[@]}"; do
 					;;
 				oraclelinux*)
 					template="Dockerfile-$downloadSource-oraclelinux.template"
-					from="oraclelinux:${variant#oraclelinux}-slim"
+					oracleVersion="${variant#oraclelinux}" # "7", "8", etc
+					from="oraclelinux:$oracleVersion-slim"
 					variantVersion="$linuxVersion"
 					variantJavaHome="/usr/java/openjdk-$javaVersion"
 					variantArchCase="$linuxArchCase"
+					if [ "$oracleVersion" -eq 7 ]; then
+						# yum vs microdnf in Oracle Linux 7
+						sedArgs+=(
+							-e "$(sed_s 'microdnf install' 'yum install -y')"
+							-e "$(sed_s 'microdnf clean all' 'rm -rf /var/cache/yum')"
+						)
+					fi
 					;;
 				windows/*)
 					variantVersion="$windowsVersion"


### PR DESCRIPTION
For `openjdk:14-jdk-oracle` this results in a ~9MB size increase.

cc @Djelibeybi -- do you think this is reasonable?  (any thoughts/review appreciated)

<details>
<summary>Diff:</summary>

```diff
$ diff -u <(bashbrew cat openjdk) <(bashbrew cat <(./generate-stackbrew-library.sh))
--- /dev/fd/63	2020-07-24 10:03:53.067812120 -0700
+++ /dev/fd/62	2020-07-24 10:03:53.071812001 -0700
@@ -1,10 +1,10 @@
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon), Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 16-ea-7-jdk-oraclelinux7, 16-ea-7-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7, 16-ea-7-jdk-oracle, 16-ea-7-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
+Tags: 16-ea-7-jdk-oraclelinux8, 16-ea-7-oraclelinux8, 16-ea-jdk-oraclelinux8, 16-ea-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, 16-ea-7-jdk-oracle, 16-ea-7-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
 SharedTags: 16-ea-7-jdk, 16-ea-7, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: amd64, arm64v8
-GitCommit: b64d9fd4cfc27a0a59d166ed4392dc5e984eb303
+GitCommit: e68ee469a61217d227514e7dd82dc3593bcb16de
 Directory: 16/jdk/oracle
 
 Tags: 16-ea-7-jdk-buster, 16-ea-7-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
@@ -42,10 +42,10 @@
 Directory: 16/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 15-ea-33-jdk-oraclelinux7, 15-ea-33-oraclelinux7, 15-ea-jdk-oraclelinux7, 15-ea-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, 15-ea-33-jdk-oracle, 15-ea-33-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
+Tags: 15-ea-33-jdk-oraclelinux8, 15-ea-33-oraclelinux8, 15-ea-jdk-oraclelinux8, 15-ea-oraclelinux8, 15-jdk-oraclelinux8, 15-oraclelinux8, 15-ea-33-jdk-oracle, 15-ea-33-oracle, 15-ea-jdk-oracle, 15-ea-oracle, 15-jdk-oracle, 15-oracle
 SharedTags: 15-ea-33-jdk, 15-ea-33, 15-ea-jdk, 15-ea, 15-jdk, 15
 Architectures: amd64, arm64v8
-GitCommit: 55eaa15885a2dd8b0d74c95fe9af71d90492b2d8
+GitCommit: e68ee469a61217d227514e7dd82dc3593bcb16de
 Directory: 15/jdk/oracle
 
 Tags: 15-ea-33-jdk-buster, 15-ea-33-buster, 15-ea-jdk-buster, 15-ea-buster, 15-jdk-buster, 15-buster
@@ -83,9 +83,9 @@
 Directory: 15/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 14.0.2-jdk-oraclelinux7, 14.0.2-oraclelinux7, 14.0-jdk-oraclelinux7, 14.0-oraclelinux7, 14-jdk-oraclelinux7, 14-oraclelinux7, jdk-oraclelinux7, oraclelinux7, 14.0.2-jdk-oracle, 14.0.2-oracle, 14.0-jdk-oracle, 14.0-oracle, 14-jdk-oracle, 14-oracle, jdk-oracle, oracle
+Tags: 14.0.2-jdk-oraclelinux8, 14.0.2-oraclelinux8, 14.0-jdk-oraclelinux8, 14.0-oraclelinux8, 14-jdk-oraclelinux8, 14-oraclelinux8, jdk-oraclelinux8, oraclelinux8, 14.0.2-jdk-oracle, 14.0.2-oracle, 14.0-jdk-oracle, 14.0-oracle, 14-jdk-oracle, 14-oracle, jdk-oracle, oracle
 SharedTags: 14.0.2-jdk, 14.0.2, 14.0-jdk, 14.0, 14-jdk, 14, jdk, latest
-GitCommit: 29c17de6c8c0df6304d0c80f569deea1d4b6a23e
+GitCommit: e68ee469a61217d227514e7dd82dc3593bcb16de
 Directory: 14/jdk/oracle
 
 Tags: 14.0.2-jdk-buster, 14.0.2-buster, 14.0-jdk-buster, 14.0-buster, 14-jdk-buster, 14-buster, jdk-buster, buster
```

</details>