### PR TITLE
Use "C.UTF-8" in Oracle Linux 8 (it doesn't have "en_US.UTF-8" like 7 did)

### DIFF
--- a/11/jdk/buster/Dockerfile
+++ b/11/jdk/buster/Dockerfile
@@ -104,6 +104,7 @@ RUN set -eux; \
 	ldconfig; \
 	\
 # basic smoke test
+	fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
 	javac --version; \
 	java --version
 

--- a/11/jdk/slim-buster/Dockerfile
+++ b/11/jdk/slim-buster/Dockerfile
@@ -108,6 +108,7 @@ RUN set -eux; \
 	ldconfig; \
 	\
 # basic smoke test
+	fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
 	javac --version; \
 	java --version
 

--- a/14/jdk/buster/Dockerfile
+++ b/14/jdk/buster/Dockerfile
@@ -87,6 +87,7 @@ RUN set -eux; \
 	java -Xshare:dump; \
 	\
 # basic smoke test
+	fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
 	javac --version; \
 	java --version
 

--- a/14/jdk/oraclelinux7/Dockerfile
+++ b/14/jdk/oraclelinux7/Dockerfile
@@ -71,6 +71,7 @@ RUN set -eux; \
 	ln -sT /etc/pki/ca-trust/extracted/java/cacerts "$JAVA_HOME/lib/security/cacerts"; \
 	\
 # basic smoke test
+	fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
 	javac --version; \
 	java --version
 

--- a/14/jdk/oraclelinux8/Dockerfile
+++ b/14/jdk/oraclelinux8/Dockerfile
@@ -15,7 +15,7 @@ RUN set -eux; \
 	microdnf clean all
 
 # Default to UTF-8 file.encoding
-ENV LANG en_US.UTF-8
+ENV LANG C.UTF-8
 
 ENV JAVA_HOME /usr/java/openjdk-14
 ENV PATH $JAVA_HOME/bin:$PATH
@@ -71,6 +71,7 @@ RUN set -eux; \
 	ln -sT /etc/pki/ca-trust/extracted/java/cacerts "$JAVA_HOME/lib/security/cacerts"; \
 	\
 # basic smoke test
+	fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
 	javac --version; \
 	java --version
 

--- a/14/jdk/slim-buster/Dockerfile
+++ b/14/jdk/slim-buster/Dockerfile
@@ -86,6 +86,7 @@ RUN set -eux; \
 	java -Xshare:dump; \
 	\
 # basic smoke test
+	fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
 	javac --version; \
 	java --version
 

--- a/15/jdk/buster/Dockerfile
+++ b/15/jdk/buster/Dockerfile
@@ -92,6 +92,7 @@ RUN set -eux; \
 	java -Xshare:dump; \
 	\
 # basic smoke test
+	fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
 	javac --version; \
 	java --version
 

--- a/15/jdk/oraclelinux7/Dockerfile
+++ b/15/jdk/oraclelinux7/Dockerfile
@@ -76,6 +76,7 @@ RUN set -eux; \
 	ln -sT /etc/pki/ca-trust/extracted/java/cacerts "$JAVA_HOME/lib/security/cacerts"; \
 	\
 # basic smoke test
+	fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
 	javac --version; \
 	java --version
 

--- a/15/jdk/oraclelinux8/Dockerfile
+++ b/15/jdk/oraclelinux8/Dockerfile
@@ -15,7 +15,7 @@ RUN set -eux; \
 	microdnf clean all
 
 # Default to UTF-8 file.encoding
-ENV LANG en_US.UTF-8
+ENV LANG C.UTF-8
 
 ENV JAVA_HOME /usr/java/openjdk-15
 ENV PATH $JAVA_HOME/bin:$PATH
@@ -76,6 +76,7 @@ RUN set -eux; \
 	ln -sT /etc/pki/ca-trust/extracted/java/cacerts "$JAVA_HOME/lib/security/cacerts"; \
 	\
 # basic smoke test
+	fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
 	javac --version; \
 	java --version
 

--- a/15/jdk/slim-buster/Dockerfile
+++ b/15/jdk/slim-buster/Dockerfile
@@ -91,6 +91,7 @@ RUN set -eux; \
 	java -Xshare:dump; \
 	\
 # basic smoke test
+	fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
 	javac --version; \
 	java --version
 

--- a/16/jdk/alpine3.12/Dockerfile
+++ b/16/jdk/alpine3.12/Dockerfile
@@ -47,6 +47,7 @@ RUN set -eux; \
 	java -Xshare:dump; \
 	\
 # basic smoke test
+	fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
 	javac --version; \
 	java --version
 

--- a/16/jdk/buster/Dockerfile
+++ b/16/jdk/buster/Dockerfile
@@ -92,6 +92,7 @@ RUN set -eux; \
 	java -Xshare:dump; \
 	\
 # basic smoke test
+	fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
 	javac --version; \
 	java --version
 

--- a/16/jdk/oraclelinux7/Dockerfile
+++ b/16/jdk/oraclelinux7/Dockerfile
@@ -76,6 +76,7 @@ RUN set -eux; \
 	ln -sT /etc/pki/ca-trust/extracted/java/cacerts "$JAVA_HOME/lib/security/cacerts"; \
 	\
 # basic smoke test
+	fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
 	javac --version; \
 	java --version
 

--- a/16/jdk/oraclelinux8/Dockerfile
+++ b/16/jdk/oraclelinux8/Dockerfile
@@ -15,7 +15,7 @@ RUN set -eux; \
 	microdnf clean all
 
 # Default to UTF-8 file.encoding
-ENV LANG en_US.UTF-8
+ENV LANG C.UTF-8
 
 ENV JAVA_HOME /usr/java/openjdk-16
 ENV PATH $JAVA_HOME/bin:$PATH
@@ -76,6 +76,7 @@ RUN set -eux; \
 	ln -sT /etc/pki/ca-trust/extracted/java/cacerts "$JAVA_HOME/lib/security/cacerts"; \
 	\
 # basic smoke test
+	fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
 	javac --version; \
 	java --version
 

--- a/16/jdk/slim-buster/Dockerfile
+++ b/16/jdk/slim-buster/Dockerfile
@@ -91,6 +91,7 @@ RUN set -eux; \
 	java -Xshare:dump; \
 	\
 # basic smoke test
+	fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
 	javac --version; \
 	java --version
 

--- a/Dockerfile-adopt-debian-slim.template
+++ b/Dockerfile-adopt-debian-slim.template
@@ -101,6 +101,7 @@ RUN set -eux; \
 	ldconfig; \
 	\
 # basic smoke test
+	fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
 	javac --version; \
 	java --version
 

--- a/Dockerfile-adopt-debian.template
+++ b/Dockerfile-adopt-debian.template
@@ -97,6 +97,7 @@ RUN set -eux; \
 	ldconfig; \
 	\
 # basic smoke test
+	fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
 	javac --version; \
 	java --version
 

--- a/Dockerfile-oracle-alpine.template
+++ b/Dockerfile-oracle-alpine.template
@@ -39,6 +39,7 @@ RUN set -eux; \
 	java -Xshare:dump; \
 	\
 # basic smoke test
+	fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
 	javac --version; \
 	java --version
 

--- a/Dockerfile-oracle-debian-slim.template
+++ b/Dockerfile-oracle-debian-slim.template
@@ -78,6 +78,7 @@ RUN set -eux; \
 	java -Xshare:dump; \
 	\
 # basic smoke test
+	fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
 	javac --version; \
 	java --version
 

--- a/Dockerfile-oracle-debian.template
+++ b/Dockerfile-oracle-debian.template
@@ -79,6 +79,7 @@ RUN set -eux; \
 	java -Xshare:dump; \
 	\
 # basic smoke test
+	fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
 	javac --version; \
 	java --version
 

--- a/Dockerfile-oracle-oraclelinux.template
+++ b/Dockerfile-oracle-oraclelinux.template
@@ -15,7 +15,7 @@ RUN set -eux; \
 	microdnf clean all
 
 # Default to UTF-8 file.encoding
-ENV LANG en_US.UTF-8
+ENV LANG C.UTF-8
 
 ENV JAVA_HOME placeholder
 ENV PATH $JAVA_HOME/bin:$PATH
@@ -63,6 +63,7 @@ RUN set -eux; \
 	ln -sT /etc/pki/ca-trust/extracted/java/cacerts "$JAVA_HOME/lib/security/cacerts"; \
 	\
 # basic smoke test
+	fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
 	javac --version; \
 	java --version
 

--- a/update.sh
+++ b/update.sh
@@ -309,10 +309,13 @@ for javaVersion in "${versions[@]}"; do
 					variantJavaHome="/usr/java/openjdk-$javaVersion"
 					variantArchCase="$linuxArchCase"
 					if [ "$oracleVersion" -eq 7 ]; then
-						# yum vs microdnf in Oracle Linux 7
 						sedArgs+=(
+							# yum vs microdnf in Oracle Linux 7
 							-e "$(sed_s 'microdnf install' 'yum install -y')"
 							-e "$(sed_s 'microdnf clean all' 'rm -rf /var/cache/yum')"
+
+							# "en_US.UTF-8" vs "C.UTF-8" in Oracle Linux 7
+							-e "$(sed_s 'C.UTF-8' 'en_US.UTF-8')"
 						)
 					fi
 					;;


### PR DESCRIPTION
Closes #430

This also adds a small smoke test to help ensure this stays working (hopefully, if it works on all variants properly :sweat_smile:).