### PR TITLE
Add alpine3.15 build for openjdk-18 and make it the new default

### DIFF
--- a/18/jdk/alpine3.15/Dockerfile
+++ b/18/jdk/alpine3.15/Dockerfile
@@ -1,0 +1,58 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM alpine:3.15
+
+RUN apk add --no-cache java-cacerts
+
+ENV JAVA_HOME /opt/openjdk-18
+ENV PATH $JAVA_HOME/bin:$PATH
+
+# https://jdk.java.net/
+# >
+# > Java Development Kit builds, from Oracle
+# >
+ENV JAVA_VERSION 18-ea+11
+# "For Alpine Linux, builds are produced on a reduced schedule and may not be in sync with the other platforms."
+
+RUN set -eux; \
+	\
+	arch="$(apk --print-arch)"; \
+	case "$arch" in \
+		'x86_64') \
+			downloadUrl='https://download.java.net/java/early_access/alpine/11/binaries/openjdk-18-ea+11_linux-x64-musl_bin.tar.gz'; \
+			downloadSha256='86fad9069587a5e9dd003e7354a69b2f720a05c12706d2f2345a0c8d90e56c47'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture: '$arch'"; exit 1 ;; \
+	esac; \
+	\
+	wget -O openjdk.tgz "$downloadUrl"; \
+	echo "$downloadSha256 *openjdk.tgz" | sha256sum -c -; \
+	\
+	mkdir -p "$JAVA_HOME"; \
+	tar --extract \
+		--file openjdk.tgz \
+		--directory "$JAVA_HOME" \
+		--strip-components 1 \
+		--no-same-owner \
+	; \
+	rm openjdk.tgz*; \
+	\
+	rm -rf "$JAVA_HOME/lib/security/cacerts"; \
+# see "java-cacerts" package installed above (which maintains "/etc/ssl/certs/java/cacerts" for us)
+	ln -sT /etc/ssl/certs/java/cacerts "$JAVA_HOME/lib/security/cacerts"; \
+	\
+# https://github.com/docker-library/openjdk/issues/212#issuecomment-420979840
+# https://openjdk.java.net/jeps/341
+	java -Xshare:dump; \
+	\
+# basic smoke test
+	fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
+	javac --version; \
+	java --version
+
+# "jshell" is an interactive REPL for Java (see https://en.wikipedia.org/wiki/JShell)
+CMD ["jshell"]

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -6,7 +6,7 @@ declare -A aliases=(
 	[17-jre]='jre'
 )
 defaultType='jdk'
-defaultAlpine='3.14'
+defaultAlpine='3.15'
 defaultDebian='bullseye'
 defaultOracle='8'
 

--- a/versions.json
+++ b/versions.json
@@ -109,6 +109,7 @@
       "slim-bullseye",
       "buster",
       "slim-buster",
+      "alpine3.15",
       "alpine3.14",
       "alpine3.13",
       "windows/windowsservercore-ltsc2022",

--- a/versions.sh
+++ b/versions.sh
@@ -274,6 +274,7 @@ for version in "${versions[@]}"; do
 					"buster"
 				| ., "slim-" + .),
 				if $doc.alpine then
+					"3.15",
 					"3.14",
 					"3.13"
 				| "alpine" + . else empty end,


### PR DESCRIPTION
Alpine 3.15 was recently released and I would love to make its new rlwrap package available to my downstream clojure image. Let me know if this needs any tweaks to be mergeable. Thanks!