### PR TITLE
Add "-rc" suffix to only-digit version numbers

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -107,6 +107,11 @@ aliases() {
 	local fullVersion="$1"; shift
 	local variants=( "$@" )
 
+	if [[ "$fullVersion" =~ ^[0-9]+$ ]]; then
+		# if fullVersion is only digits, add "-rc" to the end (because we're probably in the final-phases of pre-release before GA when we drop support from the image)
+		fullVersion="$fullVersion-rc"
+	fi
+
 	local bases=()
 	while [ "${fullVersion%[.-]*}" != "$fullVersion" ]; do
 		bases+=( $fullVersion )


### PR DESCRIPTION
The goal of this is to make the releases of OpenJDK 19 that are in between the explitit "19-ea-XX" releases and the GA release more clearly/obviously pre-release.

(compare https://jdk.java.net/20/ to https://jdk.java.net/19/ - the former is titled "OpenJDK JDK 20 Early-Access Builds" and the latter is now titled "OpenJDK JDK 19 Release-Candidate Builds")