### PR TITLE
Increase default RAM percentage for JVM

### DIFF
--- a/22/jdk/bookworm/Dockerfile
+++ b/22/jdk/bookworm/Dockerfile
@@ -39,6 +39,9 @@ ENV LANG C.UTF-8
 # >
 ENV JAVA_VERSION 22-ea+18
 
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
+
 RUN set -eux; \
 	\
 	arch="$(dpkg --print-architecture)"; \

--- a/22/jdk/bullseye/Dockerfile
+++ b/22/jdk/bullseye/Dockerfile
@@ -39,6 +39,9 @@ ENV LANG C.UTF-8
 # >
 ENV JAVA_VERSION 22-ea+18
 
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
+
 RUN set -eux; \
 	\
 	arch="$(dpkg --print-architecture)"; \

--- a/22/jdk/oraclelinux7/Dockerfile
+++ b/22/jdk/oraclelinux7/Dockerfile
@@ -33,6 +33,9 @@ ENV LANG en_US.UTF-8
 # >
 ENV JAVA_VERSION 22-ea+18
 
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
+
 RUN set -eux; \
 	\
 	arch="$(objdump="$(command -v objdump)" && objdump --file-headers "$objdump" | awk -F '[:,]+[[:space:]]+' '$1 == "architecture" { print $2 }')"; \

--- a/22/jdk/oraclelinux8/Dockerfile
+++ b/22/jdk/oraclelinux8/Dockerfile
@@ -32,6 +32,9 @@ ENV LANG C.UTF-8
 # >
 ENV JAVA_VERSION 22-ea+18
 
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
+
 RUN set -eux; \
 	\
 	arch="$(objdump="$(command -v objdump)" && objdump --file-headers "$objdump" | awk -F '[:,]+[[:space:]]+' '$1 == "architecture" { print $2 }')"; \

--- a/22/jdk/slim-bookworm/Dockerfile
+++ b/22/jdk/slim-bookworm/Dockerfile
@@ -26,6 +26,9 @@ ENV LANG C.UTF-8
 # >
 ENV JAVA_VERSION 22-ea+18
 
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
+
 RUN set -eux; \
 	\
 	arch="$(dpkg --print-architecture)"; \

--- a/22/jdk/slim-bullseye/Dockerfile
+++ b/22/jdk/slim-bullseye/Dockerfile
@@ -26,6 +26,9 @@ ENV LANG C.UTF-8
 # >
 ENV JAVA_VERSION 22-ea+18
 
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
+
 RUN set -eux; \
 	\
 	arch="$(dpkg --print-architecture)"; \

--- a/22/jdk/windows/nanoserver-1809/Dockerfile
+++ b/22/jdk/windows/nanoserver-1809/Dockerfile
@@ -22,6 +22,9 @@ USER ContainerUser
 # >
 ENV JAVA_VERSION 22-ea+18
 
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
+
 COPY --from=openjdk:22-ea-18-jdk-windowsservercore-1809 $JAVA_HOME $JAVA_HOME
 
 RUN echo Verifying install ... \

--- a/22/jdk/windows/windowsservercore-1809/Dockerfile
+++ b/22/jdk/windows/windowsservercore-1809/Dockerfile
@@ -37,6 +37,9 @@ ENV JAVA_VERSION 22-ea+18
 ENV JAVA_URL https://download.java.net/java/early_access/jdk22/18/GPL/openjdk-22-ea+18_windows-x64_bin.zip
 ENV JAVA_SHA256 9514da1d60086946d1324cfabda5280213d7243eec44e2268bbbf02248d910ff
 
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
+
 RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.zip'; \

--- a/22/jdk/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/22/jdk/windows/windowsservercore-ltsc2022/Dockerfile
@@ -37,6 +37,9 @@ ENV JAVA_VERSION 22-ea+18
 ENV JAVA_URL https://download.java.net/java/early_access/jdk22/18/GPL/openjdk-22-ea+18_windows-x64_bin.zip
 ENV JAVA_SHA256 9514da1d60086946d1324cfabda5280213d7243eec44e2268bbbf02248d910ff
 
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
+
 RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.zip'; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -120,6 +120,9 @@ ENV JAVA_VERSION {{ java_version }}
 # "For Alpine Linux, builds are produced on a reduced schedule and may not be in sync with the other platforms."
 {{ ) else "" end -}}
 
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
+
 {{
 	def arches:
 		if is_alpine then .alpine else . end

--- a/Dockerfile-windows.template
+++ b/Dockerfile-windows.template
@@ -48,6 +48,9 @@ ENV JAVA_SHA256 {{ .[env.javaType].arches["windows-amd64"].sha256 }}
 {{ ) else "" end -}}
 {{ ) else "" end -}}
 
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
+
 {{ if env.windowsVariant == "servercore" then ( -}}
 RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \


### PR DESCRIPTION
The JVM by default only uses up to 25% of available memory. Since containers are running only one JVM it makes sense to bump this up to a higher amount to better use the total container space.