### PR TITLE
Update GitHub checkout action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       strategy: ${{ steps.generate-jobs.outputs.strategy }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: docker-library/bashbrew@HEAD
       - id: generate-jobs
         name: Generate Jobs


### PR DESCRIPTION
This avoids lots of deprecation warnings in the build output.