### PR TITLE
Add Windows Server 2025 variant

### DIFF
--- a/24/jdk/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/24/jdk/windows/windowsservercore-ltsc2025/Dockerfile
@@ -1,0 +1,65 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2025
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# enable TLS 1.2
+# https://docs.microsoft.com/en-us/system-center/vmm/install-tls?view=sc-vmm-1801
+# https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs#enable-tls-12
+RUN Write-Host 'Enabling TLS 1.2 (https://githubengineering.com/crypto-removal-notice/) ...'; \
+	$tls12RegBase = 'HKLM:\\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2'; \
+	if (Test-Path $tls12RegBase) { throw ('"{0}" already exists!' -f $tls12RegBase) }; \
+	New-Item -Path ('{0}/Client' -f $tls12RegBase) -Force; \
+	New-Item -Path ('{0}/Server' -f $tls12RegBase) -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force; \
+	Write-Host 'Complete.'
+
+ENV JAVA_HOME C:\\openjdk-24
+RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+	setx /M PATH $newPath; \
+	Write-Host 'Complete.'
+
+# https://jdk.java.net/
+# >
+# > Java Development Kit builds, from Oracle
+# >
+ENV JAVA_VERSION 24-ea+31
+ENV JAVA_URL https://download.java.net/java/early_access/jdk24/31/GPL/openjdk-24-ea+31_windows-x64_bin.zip
+ENV JAVA_SHA256 72536bad2fa20c7ead0367944940a684a359e43649870d3cdbccd46bcc3b4009
+
+RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.zip'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
+	if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	New-Item -ItemType Directory -Path C:\temp | Out-Null; \
+	Expand-Archive openjdk.zip -DestinationPath C:\temp; \
+	Move-Item -Path C:\temp\* -Destination $env:JAVA_HOME; \
+	Remove-Item C:\temp; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item openjdk.zip -Force; \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  javac --version'; javac --version; \
+	Write-Host '  java --version'; java --version; \
+	\
+	Write-Host 'Complete.'
+
+# "jshell" is an interactive REPL for Java (see https://en.wikipedia.org/wiki/JShell)
+CMD ["jshell"]

--- a/25/jdk/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/25/jdk/windows/windowsservercore-ltsc2025/Dockerfile
@@ -1,0 +1,65 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2025
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# enable TLS 1.2
+# https://docs.microsoft.com/en-us/system-center/vmm/install-tls?view=sc-vmm-1801
+# https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs#enable-tls-12
+RUN Write-Host 'Enabling TLS 1.2 (https://githubengineering.com/crypto-removal-notice/) ...'; \
+	$tls12RegBase = 'HKLM:\\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2'; \
+	if (Test-Path $tls12RegBase) { throw ('"{0}" already exists!' -f $tls12RegBase) }; \
+	New-Item -Path ('{0}/Client' -f $tls12RegBase) -Force; \
+	New-Item -Path ('{0}/Server' -f $tls12RegBase) -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Client' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'DisabledByDefault' -PropertyType DWORD -Value 0 -Force; \
+	New-ItemProperty -Path ('{0}/Server' -f $tls12RegBase) -Name 'Enabled' -PropertyType DWORD -Value 1 -Force; \
+	Write-Host 'Complete.'
+
+ENV JAVA_HOME C:\\openjdk-25
+RUN $newPath = ('{0}\bin;{1}' -f $env:JAVA_HOME, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+	setx /M PATH $newPath; \
+	Write-Host 'Complete.'
+
+# https://jdk.java.net/
+# >
+# > Java Development Kit builds, from Oracle
+# >
+ENV JAVA_VERSION 25-ea+6
+ENV JAVA_URL https://download.java.net/java/early_access/jdk25/6/GPL/openjdk-25-ea+6_windows-x64_bin.zip
+ENV JAVA_SHA256 291c57a76ce4ef742a0402b2af6ae2b2eab2614738b9bc0e335ab9d06f105d33
+
+RUN Write-Host ('Downloading {0} ...' -f $env:JAVA_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:JAVA_URL -OutFile 'openjdk.zip'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JAVA_SHA256); \
+	if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	New-Item -ItemType Directory -Path C:\temp | Out-Null; \
+	Expand-Archive openjdk.zip -DestinationPath C:\temp; \
+	Move-Item -Path C:\temp\* -Destination $env:JAVA_HOME; \
+	Remove-Item C:\temp; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item openjdk.zip -Force; \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  javac --version'; javac --version; \
+	Write-Host '  java --version'; java --version; \
+	\
+	Write-Host 'Complete.'
+
+# "jshell" is an interactive REPL for Java (see https://en.wikipedia.org/wiki/JShell)
+CMD ["jshell"]

--- a/versions.json
+++ b/versions.json
@@ -23,6 +23,7 @@
       "slim-bookworm",
       "bullseye",
       "slim-bullseye",
+      "windows/windowsservercore-ltsc2025",
       "windows/windowsservercore-ltsc2022",
       "windows/windowsservercore-1809",
       "windows/nanoserver-1809"
@@ -53,6 +54,7 @@
       "slim-bookworm",
       "bullseye",
       "slim-bullseye",
+      "windows/windowsservercore-ltsc2025",
       "windows/windowsservercore-ltsc2022",
       "windows/windowsservercore-1809",
       "windows/nanoserver-1809"

--- a/versions.sh
+++ b/versions.sh
@@ -166,6 +166,7 @@ for version in "${versions[@]}"; do
 				| "alpine" + . else empty end,
 				if $doc.jdk.arches | keys | any(startswith("windows-")) then
 					(
+						"ltsc2025",
 						"ltsc2022",
 						"1809",
 						empty


### PR DESCRIPTION
Add Windows Server ltsc2025; keep 1809 as it is still in extended support (we may drop it later, even while it is supported by Windows).

Refs: https://github.com/docker-library/official-images/pull/18143